### PR TITLE
feat: set up neo-brutalist monochrome design system

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,27 +1,192 @@
-:root {
-  --font-mono: var(--font-jetbrains-mono), "JetBrains Mono", monospace;
-  --font-sans: system-ui, -apple-system, sans-serif;
-}
+@import "../styles/variables.css";
 
-* {
+/* === Reset === */
+*,
+*::before,
+*::after {
   box-sizing: border-box;
-  padding: 0;
   margin: 0;
+  padding: 0;
 }
 
-html,
-body {
-  max-width: 100vw;
-  overflow-x: hidden;
+/* === Base === */
+html {
+  font-size: 16px;
+  -webkit-text-size-adjust: 100%;
+  scroll-behavior: smooth;
 }
 
 body {
   font-family: var(--font-sans);
+  font-size: var(--text-base);
+  line-height: var(--leading-normal);
+  color: var(--color-text);
+  background-color: var(--color-bg);
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+  max-width: 100vw;
+  overflow-x: hidden;
 }
 
+/* === Typography === */
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: var(--font-mono);
+  font-weight: var(--weight-bold);
+  line-height: var(--leading-tight);
+  letter-spacing: -0.02em;
+}
+
+h1 {
+  font-size: var(--text-3xl);
+}
+
+h2 {
+  font-size: var(--text-2xl);
+}
+
+h3 {
+  font-size: var(--text-xl);
+}
+
+h4 {
+  font-size: var(--text-lg);
+}
+
+p {
+  line-height: var(--leading-relaxed);
+}
+
+code,
+pre,
+kbd {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+}
+
+pre {
+  background-color: var(--color-bg-secondary);
+  border: var(--border-medium);
+  padding: var(--space-md);
+  overflow-x: auto;
+  line-height: var(--leading-normal);
+}
+
+code {
+  background-color: var(--color-bg-secondary);
+  padding: 0.15em 0.4em;
+}
+
+pre code {
+  background: none;
+  padding: 0;
+}
+
+/* === Links === */
 a {
-  color: inherit;
+  color: var(--color-text);
   text-decoration: none;
+  border-bottom: var(--border-thin);
+  transition: none;
+}
+
+a:hover {
+  background-color: var(--color-text);
+  color: var(--color-bg);
+}
+
+a:focus-visible {
+  outline: 3px solid var(--color-text);
+  outline-offset: 2px;
+}
+
+/* === Buttons === */
+button {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-bold);
+  color: var(--color-accent-text);
+  background-color: var(--color-accent);
+  border: var(--border-medium);
+  padding: var(--space-sm) var(--space-md);
+  cursor: pointer;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  border-radius: 0;
+}
+
+button:hover {
+  color: var(--color-accent);
+  background-color: var(--color-accent-text);
+}
+
+button:focus-visible {
+  outline: 3px solid var(--color-text);
+  outline-offset: 2px;
+}
+
+/* === Images === */
+img {
+  max-width: 100%;
+  height: auto;
+  display: block;
+}
+
+/* === Selection === */
+::selection {
+  background-color: var(--color-text);
+  color: var(--color-bg);
+}
+
+/* === Scrollbar (subtle) === */
+::-webkit-scrollbar {
+  width: 8px;
+}
+
+::-webkit-scrollbar-track {
+  background: var(--color-bg);
+}
+
+::-webkit-scrollbar-thumb {
+  background: var(--color-border-muted);
+  border: 1px solid var(--color-bg);
+}
+
+/* === Skip to content === */
+.skip-to-content {
+  position: absolute;
+  top: -100%;
+  left: var(--space-md);
+  z-index: 100;
+  padding: var(--space-sm) var(--space-md);
+  background-color: var(--color-text);
+  color: var(--color-bg);
+  font-family: var(--font-mono);
+  font-weight: var(--weight-bold);
+  border: var(--border-medium);
+}
+
+.skip-to-content:focus {
+  top: var(--space-md);
+}
+
+/* === Utilities === */
+.mono {
+  font-family: var(--font-mono);
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }

--- a/app/page.module.css
+++ b/app/page.module.css
@@ -4,16 +4,19 @@
   align-items: center;
   justify-content: center;
   min-height: 100vh;
-  padding: 48px 24px;
+  padding: var(--space-2xl) var(--space-lg);
 }
 
 .title {
   font-family: var(--font-mono);
-  font-size: 48px;
-  font-weight: 700;
+  font-size: var(--text-3xl);
+  font-weight: var(--weight-black);
+  letter-spacing: -0.03em;
+  text-transform: uppercase;
 }
 
 .description {
-  margin-top: 16px;
-  font-size: 16px;
+  margin-top: var(--space-md);
+  font-size: var(--text-base);
+  color: var(--color-text-muted);
 }

--- a/styles/variables.css
+++ b/styles/variables.css
@@ -1,0 +1,75 @@
+/* Neo-Brutalist Monochrome Design System */
+
+:root {
+  /* === Colors (dark mode default) === */
+  --color-bg: #000;
+  --color-bg-secondary: #111;
+  --color-bg-tertiary: #222;
+  --color-surface: #111;
+  --color-surface-hover: #222;
+  --color-text: #fff;
+  --color-text-secondary: #ccc;
+  --color-text-muted: #999;
+  --color-border: #fff;
+  --color-border-muted: #333;
+  --color-accent: #fff;
+  --color-accent-text: #000;
+
+  /* === Typography === */
+  --font-mono: var(--font-jetbrains-mono), "JetBrains Mono", monospace;
+  --font-sans: system-ui, -apple-system, sans-serif;
+
+  --text-xs: 0.75rem;    /* 12px */
+  --text-sm: 0.875rem;   /* 14px */
+  --text-base: 1rem;     /* 16px */
+  --text-lg: 1.25rem;    /* 20px */
+  --text-xl: 1.5rem;     /* 24px */
+  --text-2xl: 2rem;      /* 32px */
+  --text-3xl: 3rem;      /* 48px */
+
+  --leading-tight: 1.1;
+  --leading-normal: 1.5;
+  --leading-relaxed: 1.75;
+
+  --weight-normal: 400;
+  --weight-medium: 500;
+  --weight-bold: 700;
+  --weight-black: 900;
+
+  /* === Spacing === */
+  --space-xs: 0.25rem;   /* 4px */
+  --space-sm: 0.5rem;    /* 8px */
+  --space-md: 1rem;      /* 16px */
+  --space-lg: 1.5rem;    /* 24px */
+  --space-xl: 2rem;      /* 32px */
+  --space-2xl: 3rem;     /* 48px */
+  --space-3xl: 4rem;     /* 64px */
+  --space-4xl: 6rem;     /* 96px */
+
+  /* === Borders === */
+  --border-thin: 1px solid var(--color-border);
+  --border-medium: 2px solid var(--color-border);
+  --border-thick: 3px solid var(--color-border);
+  --border-muted: 1px solid var(--color-border-muted);
+
+  /* === Layout === */
+  --max-width: 1200px;
+  --max-width-narrow: 800px;
+  --max-width-wide: 1440px;
+}
+
+/* Light mode */
+[data-theme="light"] {
+  --color-bg: #fff;
+  --color-bg-secondary: #f5f5f5;
+  --color-bg-tertiary: #eee;
+  --color-surface: #f5f5f5;
+  --color-surface-hover: #eee;
+  --color-text: #000;
+  --color-text-secondary: #333;
+  --color-text-muted: #666;
+  --color-border: #000;
+  --color-border-muted: #ccc;
+  --color-accent: #000;
+  --color-accent-text: #fff;
+}


### PR DESCRIPTION
## Summary
- Created `styles/variables.css` with full CSS custom properties design system
- Monochrome palette: black, white, grays only (no color accents)
- Typography scale (12-48px), spacing scale (4-96px), border system (1-3px solid, no radius)
- Dark mode default, light mode via `[data-theme="light"]` selector
- Global styles: reset, base typography, links (invert on hover), buttons, scrollbar, skip-to-content, selection
- Updated page styles to use design system variables

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes
- [ ] Reviewer: verify no hardcoded hex values in components
- [ ] Reviewer: verify dark background with white text renders correctly

Closes #2

Generated with [Claude Code](https://claude.com/claude-code)