### PR TITLE
feat: root layout with navigation and footer

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from "next";
 import { JetBrains_Mono } from "next/font/google";
+import { Header } from "@/components/Header";
+import { Footer } from "@/components/Footer";
 import "./globals.css";
 
 const jetbrainsMono = JetBrains_Mono({
@@ -9,7 +11,10 @@ const jetbrainsMono = JetBrains_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "Raj Navakoti",
+  title: {
+    default: "Raj Navakoti",
+    template: "%s | Raj Navakoti",
+  },
   description:
     "Staff Software Engineer - AI, neuroscience, enterprise architecture, DDD",
 };
@@ -21,7 +26,14 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" className={jetbrainsMono.variable}>
-      <body>{children}</body>
+      <body>
+        <a href="#main-content" className="skip-to-content">
+          Skip to content
+        </a>
+        <Header />
+        <main id="main-content">{children}</main>
+        <Footer />
+      </body>
     </html>
   );
 }

--- a/components/Footer.module.css
+++ b/components/Footer.module.css
@@ -1,0 +1,51 @@
+.footer {
+  border-top: var(--border-thick);
+  background-color: var(--color-bg);
+}
+
+.inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: var(--space-lg);
+}
+
+.links {
+  display: flex;
+  gap: var(--space-lg);
+}
+
+.link {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-bold);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  border-bottom: none;
+  padding: var(--space-xs) var(--space-sm);
+}
+
+.link:hover {
+  background-color: var(--color-text);
+  color: var(--color-bg);
+}
+
+.copyright {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+}
+
+@media (max-width: 768px) {
+  .inner {
+    flex-direction: column;
+    gap: var(--space-md);
+    text-align: center;
+  }
+
+  .links {
+    gap: var(--space-md);
+  }
+}

--- a/components/Footer.test.tsx
+++ b/components/Footer.test.tsx
@@ -1,0 +1,24 @@
+import { render, screen } from "@testing-library/react";
+import { Footer } from "./Footer";
+
+describe("Footer", () => {
+  it("renders social links", () => {
+    render(<Footer />);
+    expect(screen.getByRole("link", { name: "GitHub" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "LinkedIn" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Email" })).toBeInTheDocument();
+  });
+
+  it("renders copyright with current year", () => {
+    render(<Footer />);
+    const year = new Date().getFullYear().toString();
+    expect(screen.getByText(new RegExp(year))).toBeInTheDocument();
+  });
+
+  it("opens external links in new tab", () => {
+    render(<Footer />);
+    const githubLink = screen.getByRole("link", { name: "GitHub" });
+    expect(githubLink).toHaveAttribute("target", "_blank");
+    expect(githubLink).toHaveAttribute("rel", "noopener noreferrer");
+  });
+});

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,0 +1,33 @@
+import { socialLinks } from "@/lib/navigation";
+import styles from "./Footer.module.css";
+
+export function Footer() {
+  const currentYear = new Date().getFullYear();
+
+  return (
+    <footer className={styles.footer}>
+      <div className={styles.inner}>
+        <div className={styles.links}>
+          {socialLinks.map((link) => (
+            <a
+              key={link.href}
+              href={link.href}
+              className={styles.link}
+              target={link.href.startsWith("mailto:") ? undefined : "_blank"}
+              rel={
+                link.href.startsWith("mailto:")
+                  ? undefined
+                  : "noopener noreferrer"
+              }
+            >
+              {link.label}
+            </a>
+          ))}
+        </div>
+        <p className={styles.copyright}>
+          {currentYear} Raj Navakoti
+        </p>
+      </div>
+    </footer>
+  );
+}

--- a/components/Header.module.css
+++ b/components/Header.module.css
@@ -1,0 +1,107 @@
+.header {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  background-color: var(--color-bg);
+  border-bottom: var(--border-thick);
+}
+
+.nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: var(--space-md) var(--space-lg);
+}
+
+.logo {
+  font-family: var(--font-mono);
+  font-size: var(--text-xl);
+  font-weight: var(--weight-black);
+  letter-spacing: -0.03em;
+  text-transform: uppercase;
+  border-bottom: none;
+}
+
+.logo:hover {
+  background-color: transparent;
+  color: var(--color-text);
+}
+
+.logoAccent {
+  opacity: 0.4;
+}
+
+.menuToggle {
+  display: none;
+  font-family: var(--font-mono);
+  font-size: var(--text-base);
+  font-weight: var(--weight-bold);
+  background: none;
+  border: none;
+  color: var(--color-text);
+  padding: var(--space-xs) var(--space-sm);
+  cursor: pointer;
+}
+
+.menuToggle:hover {
+  background-color: var(--color-text);
+  color: var(--color-bg);
+}
+
+.links {
+  display: flex;
+  gap: var(--space-xl);
+  list-style: none;
+}
+
+.link {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-bold);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: var(--space-xs) var(--space-sm);
+  border-bottom: none;
+}
+
+.link:hover {
+  background-color: var(--color-text);
+  color: var(--color-bg);
+}
+
+.linkActive {
+  background-color: var(--color-text);
+  color: var(--color-bg);
+}
+
+/* Mobile */
+@media (max-width: 768px) {
+  .menuToggle {
+    display: block;
+  }
+
+  .links {
+    display: none;
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    flex-direction: column;
+    gap: 0;
+    background-color: var(--color-bg);
+    border-bottom: var(--border-thick);
+  }
+
+  .linksOpen {
+    display: flex;
+  }
+
+  .link {
+    display: block;
+    padding: var(--space-md) var(--space-lg);
+    border-bottom: var(--border-muted);
+    font-size: var(--text-base);
+  }
+}

--- a/components/Header.test.tsx
+++ b/components/Header.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Header } from "./Header";
+
+jest.mock("next/navigation", () => ({
+  usePathname: () => "/",
+}));
+
+describe("Header", () => {
+  it("renders the logo", () => {
+    render(<Header />);
+    expect(screen.getByText(/RAJ/)).toBeInTheDocument();
+  });
+
+  it("renders all navigation links", () => {
+    render(<Header />);
+    expect(screen.getByRole("link", { name: "Home" })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: "Blog" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Presentations" })
+    ).toBeInTheDocument();
+  });
+
+  it("marks the current page link as active", () => {
+    render(<Header />);
+    const homeLink = screen.getByRole("link", { name: "Home" });
+    expect(homeLink).toHaveAttribute("aria-current", "page");
+  });
+
+  it("toggles mobile menu on button click", async () => {
+    const user = userEvent.setup();
+    render(<Header />);
+    const toggle = screen.getByRole("button", { name: /menu/i });
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+
+    await user.click(toggle);
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+  });
+});

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { navLinks } from "@/lib/navigation";
+import styles from "./Header.module.css";
+
+export function Header() {
+  const pathname = usePathname();
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  return (
+    <header className={styles.header}>
+      <nav className={styles.nav} aria-label="Main navigation">
+        <Link href="/" className={styles.logo}>
+          RAJ<span className={styles.logoAccent}>_</span>N
+        </Link>
+
+        <button
+          className={styles.menuToggle}
+          onClick={() => setMenuOpen(!menuOpen)}
+          aria-expanded={menuOpen}
+          aria-controls="main-nav-links"
+          aria-label={menuOpen ? "Close menu" : "Open menu"}
+        >
+          {menuOpen ? "[X]" : "[=]"}
+        </button>
+
+        <ul
+          id="main-nav-links"
+          className={`${styles.links} ${menuOpen ? styles.linksOpen : ""}`}
+          role="list"
+        >
+          {navLinks.map((link) => (
+            <li key={link.href}>
+              <Link
+                href={link.href}
+                className={`${styles.link} ${
+                  pathname === link.href ? styles.linkActive : ""
+                }`}
+                onClick={() => setMenuOpen(false)}
+                aria-current={pathname === link.href ? "page" : undefined}
+              >
+                {link.label}
+              </Link>
+            </li>
+          ))}
+        </ul>
+      </nav>
+    </header>
+  );
+}

--- a/lib/navigation.ts
+++ b/lib/navigation.ts
@@ -1,0 +1,21 @@
+export interface NavLink {
+  label: string;
+  href: string;
+}
+
+export const navLinks: NavLink[] = [
+  { label: "Home", href: "/" },
+  { label: "Blog", href: "/blog" },
+  { label: "Presentations", href: "/presentations" },
+];
+
+export interface SocialLink {
+  label: string;
+  href: string;
+}
+
+export const socialLinks: SocialLink[] = [
+  { label: "GitHub", href: "https://github.com/rajnavakoti" },
+  { label: "LinkedIn", href: "https://linkedin.com/in/rajnavakoti" },
+  { label: "Email", href: "mailto:rajnavakoti@gmail.com" },
+];


### PR DESCRIPTION
## Summary
- Sticky header with logo (RAJ_N), nav links, and mobile hamburger menu
- Active page indicator via `aria-current` and inverted background
- Footer with social links (GitHub, LinkedIn, Email) and copyright
- Skip-to-content link for keyboard accessibility
- Navigation data externalized to `lib/navigation.ts`
- Semantic HTML: `<header>`, `<nav>`, `<main>`, `<footer>`

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes (8 tests: Header 4, Footer 3, Home 1)
- [ ] Reviewer: verify mobile menu toggle works at < 768px
- [ ] Reviewer: verify skip-to-content link appears on Tab

Closes #3

Generated with [Claude Code](https://claude.com/claude-code)