### PR TITLE
feat: build home/about page

### DIFF
--- a/app/page.module.css
+++ b/app/page.module.css
@@ -1,22 +1,188 @@
-.main {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  min-height: 100vh;
+.page {
+  max-width: var(--max-width-narrow);
+  margin: 0 auto;
   padding: var(--space-2xl) var(--space-lg);
+}
+
+/* === Hero === */
+.hero {
+  padding: var(--space-4xl) 0 var(--space-3xl);
+  border-bottom: var(--border-thick);
+}
+
+.greeting {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  margin-bottom: var(--space-sm);
+}
+
+.name {
+  font-size: var(--text-3xl);
+  font-weight: var(--weight-black);
+  text-transform: uppercase;
+  letter-spacing: -0.03em;
+  line-height: 1;
+  margin-bottom: var(--space-sm);
 }
 
 .title {
   font-family: var(--font-mono);
-  font-size: var(--text-3xl);
-  font-weight: var(--weight-black);
-  letter-spacing: -0.03em;
-  text-transform: uppercase;
+  font-size: var(--text-lg);
+  font-weight: var(--weight-bold);
+  margin-bottom: var(--space-lg);
 }
 
-.description {
-  margin-top: var(--space-md);
-  font-size: var(--text-base);
+.tagline {
+  font-size: var(--text-lg);
+  color: var(--color-text-secondary);
+  max-width: 600px;
+  line-height: var(--leading-relaxed);
+}
+
+/* === Sections === */
+.section {
+  padding: var(--space-2xl) 0;
+  border-bottom: var(--border-muted);
+}
+
+.sectionTitle {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-bold);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
   color: var(--color-text-muted);
+  margin-bottom: var(--space-xl);
+}
+
+/* === About === */
+.aboutContent {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.paragraph {
+  font-size: var(--text-base);
+  color: var(--color-text-secondary);
+  line-height: var(--leading-relaxed);
+  max-width: 65ch;
+}
+
+/* === Current Focus === */
+.focusList {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.focusItem {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-sm);
+}
+
+.bullet {
+  color: var(--color-text-muted);
+  flex-shrink: 0;
+}
+
+/* === Speaking === */
+.speakingGroup {
+  margin-bottom: var(--space-xl);
+}
+
+.speakingGroup:last-child {
+  margin-bottom: 0;
+}
+
+.speakingLabel {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-bold);
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  color: var(--color-text-muted);
+  margin-bottom: var(--space-md);
+}
+
+.engagements {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.talkCard {
+  padding: var(--space-md);
+  border: var(--border-thin);
+  background-color: var(--color-surface);
+}
+
+.talkCard:hover {
+  background-color: var(--color-surface-hover);
+}
+
+.talkTitle {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-bold);
+  margin-bottom: var(--space-xs);
+}
+
+.talkMeta {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+}
+
+/* === Connect === */
+.linkGrid {
+  display: flex;
+  gap: var(--space-md);
+  flex-wrap: wrap;
+}
+
+.connectLink {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-bold);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: var(--space-sm) var(--space-md);
+  border: var(--border-medium);
+  border-bottom: var(--border-medium);
+  background-color: var(--color-bg);
+}
+
+.connectLink:hover {
+  background-color: var(--color-text);
+  color: var(--color-bg);
+}
+
+.arrow {
+  display: inline;
+}
+
+/* === Mobile === */
+@media (max-width: 768px) {
+  .page {
+    padding: var(--space-lg) var(--space-md);
+  }
+
+  .hero {
+    padding: var(--space-2xl) 0 var(--space-xl);
+  }
+
+  .name {
+    font-size: var(--text-2xl);
+  }
+
+  .tagline {
+    font-size: var(--text-base);
+  }
 }

--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -2,8 +2,44 @@ import { render, screen } from "@testing-library/react";
 import Home from "./page";
 
 describe("Home", () => {
-  it("renders the page title", () => {
+  it("renders the hero section with name and title", () => {
     render(<Home />);
-    expect(screen.getByText("mono-space")).toBeInTheDocument();
+    expect(screen.getByText("Raj Navakoti")).toBeInTheDocument();
+    expect(screen.getByText("Staff Software Engineer")).toBeInTheDocument();
+  });
+
+  it("renders about section", () => {
+    render(<Home />);
+    expect(screen.getByText("// about")).toBeInTheDocument();
+  });
+
+  it("renders current focus items", () => {
+    render(<Home />);
+    expect(screen.getByText("// current focus")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Demand-Driven Context framework/)
+    ).toBeInTheDocument();
+  });
+
+  it("renders speaking engagements", () => {
+    render(<Home />);
+    expect(screen.getByText("// speaking")).toBeInTheDocument();
+    expect(screen.getByText("Upcoming")).toBeInTheDocument();
+    expect(screen.getByText("Past")).toBeInTheDocument();
+  });
+
+  it("renders connect links", () => {
+    render(<Home />);
+    expect(screen.getByText("// connect")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /GitHub/ })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /LinkedIn/ })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Email/ })).toBeInTheDocument();
+  });
+
+  it("opens external links in new tab", () => {
+    render(<Home />);
+    const githubLink = screen.getByRole("link", { name: /GitHub/ });
+    expect(githubLink).toHaveAttribute("target", "_blank");
+    expect(githubLink).toHaveAttribute("rel", "noopener noreferrer");
   });
 });

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,10 +1,110 @@
+import { profile } from "@/content/profile";
 import styles from "./page.module.css";
 
 export default function Home() {
+  const upcoming = profile.speaking.filter((s) => s.upcoming);
+  const past = profile.speaking.filter((s) => !s.upcoming);
+
   return (
-    <main className={styles.main}>
-      <h1 className={styles.title}>mono-space</h1>
-      <p className={styles.description}>Coming soon.</p>
-    </main>
+    <div className={styles.page}>
+      <section className={styles.hero}>
+        <p className={styles.greeting}>Hello, I&apos;m</p>
+        <h1 className={styles.name}>{profile.name}</h1>
+        <p className={styles.title}>{profile.title}</p>
+        <p className={styles.tagline}>{profile.tagline}</p>
+      </section>
+
+      <section className={styles.section} aria-labelledby="about-heading">
+        <h2 id="about-heading" className={styles.sectionTitle}>
+          // about
+        </h2>
+        <div className={styles.aboutContent}>
+          {profile.about.map((paragraph, i) => (
+            <p key={i} className={styles.paragraph}>
+              {paragraph}
+            </p>
+          ))}
+        </div>
+      </section>
+
+      <section className={styles.section} aria-labelledby="focus-heading">
+        <h2 id="focus-heading" className={styles.sectionTitle}>
+          // current focus
+        </h2>
+        <ul className={styles.focusList}>
+          {profile.currentFocus.map((item) => (
+            <li key={item} className={styles.focusItem}>
+              <span className={styles.bullet} aria-hidden="true">
+                &gt;
+              </span>
+              {item}
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      <section className={styles.section} aria-labelledby="speaking-heading">
+        <h2 id="speaking-heading" className={styles.sectionTitle}>
+          // speaking
+        </h2>
+
+        {upcoming.length > 0 && (
+          <div className={styles.speakingGroup}>
+            <h3 className={styles.speakingLabel}>Upcoming</h3>
+            <div className={styles.engagements}>
+              {upcoming.map((talk) => (
+                <article key={talk.title} className={styles.talkCard}>
+                  <p className={styles.talkTitle}>{talk.title}</p>
+                  <p className={styles.talkMeta}>
+                    {talk.event} &mdash; {talk.date}
+                  </p>
+                </article>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {past.length > 0 && (
+          <div className={styles.speakingGroup}>
+            <h3 className={styles.speakingLabel}>Past</h3>
+            <div className={styles.engagements}>
+              {past.map((talk) => (
+                <article key={talk.title} className={styles.talkCard}>
+                  <p className={styles.talkTitle}>{talk.title}</p>
+                  <p className={styles.talkMeta}>
+                    {talk.event} &mdash; {talk.date}
+                  </p>
+                </article>
+              ))}
+            </div>
+          </div>
+        )}
+      </section>
+
+      <section className={styles.section} aria-labelledby="links-heading">
+        <h2 id="links-heading" className={styles.sectionTitle}>
+          // connect
+        </h2>
+        <div className={styles.linkGrid}>
+          {profile.links.map((link) => (
+            <a
+              key={link.href}
+              href={link.href}
+              className={styles.connectLink}
+              target={link.external ? "_blank" : undefined}
+              rel={link.external ? "noopener noreferrer" : undefined}
+            >
+              {link.label}
+              {link.external && (
+                <span className={styles.arrow} aria-hidden="true">
+                  {" "}
+                  &rarr;
+                </span>
+              )}
+            </a>
+          ))}
+        </div>
+      </section>
+    </div>
   );
 }

--- a/content/profile.ts
+++ b/content/profile.ts
@@ -1,0 +1,68 @@
+export interface Profile {
+  name: string;
+  title: string;
+  tagline: string;
+  about: string[];
+  currentFocus: string[];
+  links: ProfileLink[];
+  speaking: SpeakingEngagement[];
+}
+
+export interface ProfileLink {
+  label: string;
+  href: string;
+  external?: boolean;
+}
+
+export interface SpeakingEngagement {
+  title: string;
+  event: string;
+  date: string;
+  upcoming: boolean;
+  url?: string;
+}
+
+export const profile: Profile = {
+  name: "Raj Navakoti",
+  title: "Staff Software Engineer",
+  tagline: "Building at the intersection of AI, architecture, and human cognition.",
+  about: [
+    "I design and build software systems that scale. My work spans enterprise architecture, domain-driven design, and applied AI. I'm fascinated by how neuroscience principles can inform better software design.",
+    "Currently focused on demand-driven architecture methodologies and exploring how large language models can augment software engineering workflows.",
+  ],
+  currentFocus: [
+    "Demand-Driven Context framework for architecture knowledge",
+    "AI-augmented development workflows with Claude Code",
+    "Enterprise DDD at scale",
+    "Neuroscience-inspired system design",
+  ],
+  links: [
+    { label: "GitHub", href: "https://github.com/rajnavakoti", external: true },
+    {
+      label: "LinkedIn",
+      href: "https://linkedin.com/in/rajnavakoti",
+      external: true,
+    },
+    { label: "Email", href: "mailto:rajnavakoti@gmail.com" },
+  ],
+  speaking: [
+    {
+      title: "Demand-Driven Context: A New Framework for Architecture Knowledge",
+      event: "NDC 2026",
+      date: "2026-06-15",
+      upcoming: true,
+    },
+    {
+      title: "Reverse-Engineering DDD in Legacy Systems",
+      event: "DDD Europe 2026",
+      date: "2026-02-10",
+      upcoming: false,
+    },
+    {
+      title: "AI-Augmented Architecture Decision Records",
+      event: "GOTO Copenhagen 2025",
+      date: "2025-11-20",
+      upcoming: false,
+    },
+  ],
+};


### PR DESCRIPTION
## Summary
- Hero section: name, title (Staff Software Engineer), tagline
- About section with background and passions
- Current focus list with terminal-style `>` bullets
- Speaking engagements split into Upcoming/Past with card layout
- Connect links (GitHub, LinkedIn, Email) with arrow indicators
- All data driven from `content/profile.ts` — zero hardcoded content
- Section headings use `// comment` style for code aesthetic

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes (13 tests total)
- [ ] Reviewer: verify all sections render at mobile (320px) and desktop (1440px)
- [ ] Reviewer: verify data comes from profile.ts, not hardcoded

Closes #4

Generated with [Claude Code](https://claude.com/claude-code)