### PR TITLE
feat: dark/light mode toggle with persistence

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from "next";
 import { JetBrains_Mono } from "next/font/google";
 import { Header } from "@/components/Header";
 import { Footer } from "@/components/Footer";
+import { ThemeProvider } from "@/components/ThemeProvider";
+import { ThemeScript } from "@/components/ThemeScript";
 import "./globals.css";
 
 const jetbrainsMono = JetBrains_Mono({
@@ -25,14 +27,19 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className={jetbrainsMono.variable}>
+    <html lang="en" className={jetbrainsMono.variable} suppressHydrationWarning>
+      <head>
+        <ThemeScript />
+      </head>
       <body>
-        <a href="#main-content" className="skip-to-content">
-          Skip to content
-        </a>
-        <Header />
-        <main id="main-content">{children}</main>
-        <Footer />
+        <ThemeProvider>
+          <a href="#main-content" className="skip-to-content">
+            Skip to content
+          </a>
+          <Header />
+          <main id="main-content">{children}</main>
+          <Footer />
+        </ThemeProvider>
       </body>
     </html>
   );

--- a/components/Header.module.css
+++ b/components/Header.module.css
@@ -33,6 +33,12 @@
   opacity: 0.4;
 }
 
+.controls {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+}
+
 .menuToggle {
   display: none;
   font-family: var(--font-mono);

--- a/components/Header.test.tsx
+++ b/components/Header.test.tsx
@@ -1,19 +1,28 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Header } from "./Header";
+import { ThemeProvider } from "./ThemeProvider";
 
 jest.mock("next/navigation", () => ({
   usePathname: () => "/",
 }));
 
+function renderHeader() {
+  return render(
+    <ThemeProvider>
+      <Header />
+    </ThemeProvider>
+  );
+}
+
 describe("Header", () => {
   it("renders the logo", () => {
-    render(<Header />);
+    renderHeader();
     expect(screen.getByText(/RAJ/)).toBeInTheDocument();
   });
 
   it("renders all navigation links", () => {
-    render(<Header />);
+    renderHeader();
     expect(screen.getByRole("link", { name: "Home" })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Blog" })).toBeInTheDocument();
     expect(
@@ -22,14 +31,14 @@ describe("Header", () => {
   });
 
   it("marks the current page link as active", () => {
-    render(<Header />);
+    renderHeader();
     const homeLink = screen.getByRole("link", { name: "Home" });
     expect(homeLink).toHaveAttribute("aria-current", "page");
   });
 
   it("toggles mobile menu on button click", async () => {
     const user = userEvent.setup();
-    render(<Header />);
+    renderHeader();
     const toggle = screen.getByRole("button", { name: /menu/i });
     expect(toggle).toHaveAttribute("aria-expanded", "false");
 

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { navLinks } from "@/lib/navigation";
+import { ThemeToggle } from "./ThemeToggle";
 import styles from "./Header.module.css";
 
 export function Header() {
@@ -17,15 +18,18 @@ export function Header() {
           RAJ<span className={styles.logoAccent}>_</span>N
         </Link>
 
-        <button
-          className={styles.menuToggle}
+        <div className={styles.controls}>
+          <ThemeToggle />
+          <button
+            className={styles.menuToggle}
           onClick={() => setMenuOpen(!menuOpen)}
           aria-expanded={menuOpen}
           aria-controls="main-nav-links"
           aria-label={menuOpen ? "Close menu" : "Open menu"}
         >
           {menuOpen ? "[X]" : "[=]"}
-        </button>
+          </button>
+        </div>
 
         <ul
           id="main-nav-links"

--- a/components/ThemeProvider.tsx
+++ b/components/ThemeProvider.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
+
+type Theme = "dark" | "light";
+
+interface ThemeContextValue {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+export function useTheme(): ThemeContextValue {
+  const context = useContext(ThemeContext);
+  if (!context) {
+    throw new Error("useTheme must be used within a ThemeProvider");
+  }
+  return context;
+}
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setTheme] = useState<Theme>("dark");
+  const [mounted, setMounted] = useState(false);
+
+  useEffect(() => {
+    const stored = localStorage.getItem("theme") as Theme | null;
+    if (stored === "light" || stored === "dark") {
+      setTheme(stored);
+    }
+    setMounted(true);
+  }, []);
+
+  useEffect(() => {
+    if (!mounted) return;
+    document.documentElement.setAttribute("data-theme", theme);
+    localStorage.setItem("theme", theme);
+  }, [theme, mounted]);
+
+  const toggleTheme = useCallback(() => {
+    setTheme((prev) => (prev === "dark" ? "light" : "dark"));
+  }, []);
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}

--- a/components/ThemeScript.tsx
+++ b/components/ThemeScript.tsx
@@ -1,0 +1,10 @@
+export function ThemeScript() {
+  const script = `
+    (function() {
+      var theme = localStorage.getItem('theme') || 'dark';
+      document.documentElement.setAttribute('data-theme', theme);
+    })();
+  `;
+
+  return <script dangerouslySetInnerHTML={{ __html: script }} />;
+}

--- a/components/ThemeToggle.module.css
+++ b/components/ThemeToggle.module.css
@@ -1,0 +1,21 @@
+.toggle {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-bold);
+  background: none;
+  border: none;
+  color: var(--color-text);
+  padding: var(--space-xs) var(--space-sm);
+  cursor: pointer;
+  letter-spacing: 0.05em;
+}
+
+.toggle:hover {
+  background-color: var(--color-text);
+  color: var(--color-bg);
+}
+
+.toggle:focus-visible {
+  outline: 3px solid var(--color-text);
+  outline-offset: 2px;
+}

--- a/components/ThemeToggle.test.tsx
+++ b/components/ThemeToggle.test.tsx
@@ -1,0 +1,70 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ThemeProvider } from "./ThemeProvider";
+import { ThemeToggle } from "./ThemeToggle";
+
+const localStorageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => {
+      store[key] = value;
+    },
+    clear: () => {
+      store = {};
+    },
+  };
+})();
+
+Object.defineProperty(window, "localStorage", {
+  value: localStorageMock,
+});
+
+function renderWithTheme() {
+  return render(
+    <ThemeProvider>
+      <ThemeToggle />
+    </ThemeProvider>
+  );
+}
+
+describe("ThemeToggle", () => {
+  beforeEach(() => {
+    localStorageMock.clear();
+    document.documentElement.removeAttribute("data-theme");
+  });
+
+  it("renders with dark mode label by default", () => {
+    renderWithTheme();
+    expect(
+      screen.getByRole("button", { name: /switch to light mode/i })
+    ).toBeInTheDocument();
+  });
+
+  it("displays [LT] text in dark mode", () => {
+    renderWithTheme();
+    expect(screen.getByText("[LT]")).toBeInTheDocument();
+  });
+
+  it("toggles to light mode on click", async () => {
+    const user = userEvent.setup();
+    renderWithTheme();
+
+    const button = screen.getByRole("button", { name: /switch to light mode/i });
+    await user.click(button);
+
+    expect(screen.getByText("[DK]")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /switch to dark mode/i })
+    ).toBeInTheDocument();
+  });
+
+  it("persists theme to localStorage", async () => {
+    const user = userEvent.setup();
+    renderWithTheme();
+
+    await user.click(screen.getByRole("button", { name: /switch to light mode/i }));
+
+    expect(localStorageMock.getItem("theme")).toBe("light");
+  });
+});

--- a/components/ThemeToggle.tsx
+++ b/components/ThemeToggle.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { useTheme } from "./ThemeProvider";
+import styles from "./ThemeToggle.module.css";
+
+export function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme();
+
+  return (
+    <button
+      className={styles.toggle}
+      onClick={toggleTheme}
+      aria-label={`Switch to ${theme === "dark" ? "light" : "dark"} mode`}
+      title={`Switch to ${theme === "dark" ? "light" : "dark"} mode`}
+    >
+      {theme === "dark" ? "[LT]" : "[DK]"}
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- `ThemeProvider` — React context managing theme state, syncs to `data-theme` attribute and localStorage
- `ThemeToggle` — button in header displaying `[LT]`/`[DK]`, neo-brutalist style
- `ThemeScript` — inline script in `<head>` prevents flash of wrong theme on page load
- Dark mode default, light mode via `[data-theme="light"]` CSS variable swap
- All existing components already use CSS variables — both modes work automatically

## Test plan
- [x] `npm run build` passes
- [x] `npm test` passes (17 tests)
- [ ] Reviewer: toggle between dark/light and verify all sections render correctly
- [ ] Reviewer: refresh page and verify theme persists
- [ ] Reviewer: clear localStorage and verify dark mode is default

Closes #21

Generated with [Claude Code](https://claude.com/claude-code)