### PR TITLE
feat: blog listing and individual post pages

### DIFF
--- a/app/blog/[slug]/page.module.css
+++ b/app/blog/[slug]/page.module.css
@@ -1,0 +1,161 @@
+.article {
+  max-width: var(--max-width-narrow);
+  margin: 0 auto;
+  padding: var(--space-2xl) var(--space-lg);
+}
+
+.header {
+  padding-bottom: var(--space-xl);
+  border-bottom: var(--border-thick);
+  margin-bottom: var(--space-xl);
+}
+
+.meta {
+  display: flex;
+  gap: var(--space-md);
+  margin-bottom: var(--space-md);
+}
+
+.date {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+}
+
+.readingTime {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+}
+
+.title {
+  font-size: var(--text-2xl);
+  font-weight: var(--weight-black);
+  line-height: var(--leading-tight);
+  margin-bottom: var(--space-md);
+}
+
+.tags {
+  display: flex;
+  gap: var(--space-sm);
+  flex-wrap: wrap;
+}
+
+.tag {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-bold);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 2px var(--space-sm);
+  border: var(--border-thin);
+  color: var(--color-text-muted);
+}
+
+/* === MDX Content Styles === */
+.content {
+  line-height: var(--leading-relaxed);
+}
+
+.content h2 {
+  font-size: var(--text-xl);
+  margin-top: var(--space-2xl);
+  margin-bottom: var(--space-md);
+  padding-bottom: var(--space-sm);
+  border-bottom: var(--border-muted);
+}
+
+.content h3 {
+  font-size: var(--text-lg);
+  margin-top: var(--space-xl);
+  margin-bottom: var(--space-sm);
+}
+
+.content p {
+  margin-bottom: var(--space-md);
+  color: var(--color-text-secondary);
+}
+
+.content ul,
+.content ol {
+  margin-bottom: var(--space-md);
+  padding-left: var(--space-lg);
+}
+
+.content li {
+  margin-bottom: var(--space-xs);
+  color: var(--color-text-secondary);
+}
+
+.content pre {
+  margin-bottom: var(--space-lg);
+  border: var(--border-medium);
+  background-color: var(--color-bg-secondary);
+  padding: var(--space-md);
+  overflow-x: auto;
+}
+
+.content code {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+}
+
+.content pre code {
+  background: none;
+  padding: 0;
+}
+
+.content blockquote {
+  border-left: var(--border-thick);
+  padding-left: var(--space-md);
+  margin-bottom: var(--space-md);
+  color: var(--color-text-muted);
+  font-style: italic;
+}
+
+.content strong {
+  font-weight: var(--weight-bold);
+  color: var(--color-text);
+}
+
+.content a {
+  border-bottom: var(--border-thin);
+}
+
+.content a:hover {
+  background-color: var(--color-text);
+  color: var(--color-bg);
+}
+
+/* === Footer === */
+.footer {
+  margin-top: var(--space-2xl);
+  padding-top: var(--space-lg);
+  border-top: var(--border-thick);
+}
+
+.backLink {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-bold);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: var(--space-sm) var(--space-md);
+  border: var(--border-medium);
+  border-bottom: var(--border-medium);
+}
+
+.backLink:hover {
+  background-color: var(--color-text);
+  color: var(--color-bg);
+}
+
+@media (max-width: 768px) {
+  .article {
+    padding: var(--space-lg) var(--space-md);
+  }
+
+  .title {
+    font-size: var(--text-xl);
+  }
+}

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -1,0 +1,68 @@
+import { notFound } from "next/navigation";
+import { compileMDX } from "next-mdx-remote/rsc";
+import { getAllSlugs, getPostBySlug } from "@/lib/blog";
+import type { BlogFrontmatter } from "@/lib/blog";
+import type { Metadata } from "next";
+import styles from "./page.module.css";
+
+interface PageProps {
+  params: Promise<{ slug: string }>;
+}
+
+export async function generateStaticParams() {
+  return getAllSlugs().map((slug) => ({ slug }));
+}
+
+export async function generateMetadata({
+  params,
+}: PageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const post = getPostBySlug(slug);
+  if (!post) return {};
+
+  return {
+    title: post.frontmatter.title,
+    description: post.frontmatter.excerpt,
+  };
+}
+
+export default async function BlogPostPage({ params }: PageProps) {
+  const { slug } = await params;
+  const post = getPostBySlug(slug);
+
+  if (!post) {
+    notFound();
+  }
+
+  const { content } = await compileMDX<BlogFrontmatter>({
+    source: post.content,
+    options: { parseFrontmatter: false },
+  });
+
+  return (
+    <article className={styles.article}>
+      <header className={styles.header}>
+        <div className={styles.meta}>
+          <time className={styles.date}>{post.frontmatter.date}</time>
+          <span className={styles.readingTime}>{post.readingTime}</span>
+        </div>
+        <h1 className={styles.title}>{post.frontmatter.title}</h1>
+        <div className={styles.tags}>
+          {post.frontmatter.tags.map((tag) => (
+            <span key={tag} className={styles.tag}>
+              {tag}
+            </span>
+          ))}
+        </div>
+      </header>
+
+      <div className={styles.content}>{content}</div>
+
+      <footer className={styles.footer}>
+        <a href="/blog" className={styles.backLink}>
+          &larr; Back to blog
+        </a>
+      </footer>
+    </article>
+  );
+}

--- a/app/blog/page.module.css
+++ b/app/blog/page.module.css
@@ -1,0 +1,118 @@
+.page {
+  max-width: var(--max-width-narrow);
+  margin: 0 auto;
+  padding: var(--space-2xl) var(--space-lg);
+}
+
+.header {
+  padding-bottom: var(--space-2xl);
+  border-bottom: var(--border-thick);
+  margin-bottom: var(--space-2xl);
+}
+
+.title {
+  font-family: var(--font-mono);
+  font-size: var(--text-2xl);
+  font-weight: var(--weight-black);
+  text-transform: uppercase;
+  margin-bottom: var(--space-sm);
+}
+
+.subtitle {
+  color: var(--color-text-muted);
+  font-size: var(--text-base);
+}
+
+.empty {
+  color: var(--color-text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+}
+
+.postList {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+}
+
+.postLink {
+  border-bottom: none;
+  display: block;
+}
+
+.postLink:hover {
+  background-color: transparent;
+  color: inherit;
+}
+
+.postCard {
+  padding: var(--space-lg);
+  border: var(--border-thin);
+  background-color: var(--color-surface);
+}
+
+.postCard:hover {
+  background-color: var(--color-surface-hover);
+  border-color: var(--color-text);
+}
+
+.postMeta {
+  display: flex;
+  gap: var(--space-md);
+  margin-bottom: var(--space-sm);
+}
+
+.date {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+}
+
+.readingTime {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+}
+
+.postTitle {
+  font-family: var(--font-mono);
+  font-size: var(--text-lg);
+  font-weight: var(--weight-bold);
+  margin-bottom: var(--space-sm);
+  line-height: var(--leading-tight);
+}
+
+.excerpt {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  line-height: var(--leading-relaxed);
+  margin-bottom: var(--space-md);
+}
+
+.tags {
+  display: flex;
+  gap: var(--space-sm);
+  flex-wrap: wrap;
+}
+
+.tag {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-bold);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 2px var(--space-sm);
+  border: var(--border-thin);
+  color: var(--color-text-muted);
+}
+
+@media (max-width: 768px) {
+  .page {
+    padding: var(--space-lg) var(--space-md);
+  }
+
+  .postTitle {
+    font-size: var(--text-base);
+  }
+}

--- a/app/blog/page.test.tsx
+++ b/app/blog/page.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen } from "@testing-library/react";
+import BlogPage from "./page";
+
+jest.mock("next/link", () => {
+  return function MockLink({
+    children,
+    href,
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) {
+    return <a href={href}>{children}</a>;
+  };
+});
+
+describe("BlogPage", () => {
+  it("renders the blog heading", () => {
+    render(<BlogPage />);
+    expect(screen.getByText("// blog")).toBeInTheDocument();
+  });
+
+  it("renders blog posts with titles", () => {
+    render(<BlogPage />);
+    expect(
+      screen.getByText(/Reverse-Engineering DDD/)
+    ).toBeInTheDocument();
+  });
+
+  it("shows reading time for each post", () => {
+    render(<BlogPage />);
+    expect(screen.getByText(/min read/)).toBeInTheDocument();
+  });
+
+  it("shows tags for each post", () => {
+    render(<BlogPage />);
+    expect(screen.getByText("DDD")).toBeInTheDocument();
+    expect(screen.getByText("architecture")).toBeInTheDocument();
+  });
+
+  it("links to individual blog posts", () => {
+    render(<BlogPage />);
+    const link = screen.getByRole("link", {
+      name: /Reverse-Engineering DDD/,
+    });
+    expect(link).toHaveAttribute(
+      "href",
+      "/blog/reverse-engineering-ddd"
+    );
+  });
+});

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,0 +1,62 @@
+import Link from "next/link";
+import { getAllPosts } from "@/lib/blog";
+import styles from "./page.module.css";
+
+export const metadata = {
+  title: "Blog",
+  description: "Writing about DDD, architecture, AI, and software engineering.",
+};
+
+export default function BlogPage() {
+  const posts = getAllPosts();
+
+  return (
+    <div className={styles.page}>
+      <header className={styles.header}>
+        <h1 className={styles.title}>// blog</h1>
+        <p className={styles.subtitle}>
+          Writing about architecture, DDD, AI, and engineering.
+        </p>
+      </header>
+
+      {posts.length === 0 ? (
+        <p className={styles.empty}>No posts yet.</p>
+      ) : (
+        <ul className={styles.postList}>
+          {posts.map((post) => (
+            <li key={post.slug}>
+              <Link
+                href={`/blog/${post.slug}`}
+                className={styles.postLink}
+              >
+                <article className={styles.postCard}>
+                  <div className={styles.postMeta}>
+                    <time className={styles.date}>
+                      {post.frontmatter.date}
+                    </time>
+                    <span className={styles.readingTime}>
+                      {post.readingTime}
+                    </span>
+                  </div>
+                  <h2 className={styles.postTitle}>
+                    {post.frontmatter.title}
+                  </h2>
+                  <p className={styles.excerpt}>
+                    {post.frontmatter.excerpt}
+                  </p>
+                  <div className={styles.tags}>
+                    {post.frontmatter.tags.map((tag) => (
+                      <span key={tag} className={styles.tag}>
+                        {tag}
+                      </span>
+                    ))}
+                  </div>
+                </article>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- `/blog` — listing page with all published posts (newest first), showing title, date, reading time, tags, excerpt
- `/blog/[slug]` — individual post page rendering full MDX with monochrome code blocks
- Post header with date, reading time, tags
- MDX content styles: headings, code blocks, blockquotes, lists, links
- "Back to blog" link in footer
- Both pages statically generated via `generateStaticParams`

## Test plan
- [x] `npm run build` passes — both routes statically generated
- [x] `npm test` passes (28 tests, 5 new for blog listing)
- [ ] Reviewer: click Blog nav link, verify listing renders
- [ ] Reviewer: click post, verify MDX content renders with code blocks
- [ ] Reviewer: verify both dark and light modes look correct

Closes #6
Closes #7

Generated with [Claude Code](https://claude.com/claude-code)