### PR TITLE
feat: add sample blog posts

### DIFF
--- a/content/blog/ai-augmented-architecture-decisions.mdx
+++ b/content/blog/ai-augmented-architecture-decisions.mdx
@@ -1,0 +1,72 @@
+---
+title: "AI-Augmented Architecture Decision Records"
+date: "2026-02-15"
+tags: ["AI", "architecture", "engineering"]
+excerpt: "What happens when you pair an LLM with your ADR process? Better context, faster decisions, and fewer regrets."
+published: true
+---
+
+Architecture Decision Records have been around for years. They work. But they have a problem: they rely on whoever writes them to capture the full context. And context is the first thing we forget.
+
+## The Context Problem
+
+Every ADR has a "Context" section. In practice, it reads like this:
+
+> We need to choose a message broker.
+
+That's it. Six months later, nobody remembers why RabbitMQ lost to Kafka, what constraints existed, or which stakeholders had concerns.
+
+```typescript
+// A typical ADR interface
+interface ArchitectureDecisionRecord {
+  id: string;
+  title: string;
+  status: "proposed" | "accepted" | "deprecated" | "superseded";
+  context: string;    // Often one vague paragraph
+  decision: string;
+  consequences: string[];
+}
+```
+
+## Enter the AI Augmentation Layer
+
+What if an LLM could interview you while you write the ADR? Not generate it for you — augment your thinking.
+
+The process works like this:
+
+- **Context expansion.** You state the decision. The AI asks clarifying questions: "What are the non-functional requirements? What did you consider and reject? What constraints does the existing system impose?"
+- **Consequence analysis.** The AI surfaces potential consequences you haven't considered, based on patterns from similar architectural decisions.
+- **Stakeholder simulation.** The AI role-plays different stakeholders: "As a security engineer, I'd want to know about encryption at rest."
+
+## The Implementation
+
+We built a simple CLI tool that wraps the ADR creation process:
+
+```typescript
+async function augmentADR(draft: ArchitectureDecisionRecord): Promise<AugmentedADR> {
+  const questions = await generateClarifyingQuestions(draft);
+  const expandedContext = await expandContext(draft, questions);
+  const consequences = await analyzeConsequences(draft);
+
+  return {
+    ...draft,
+    context: expandedContext,
+    consequences: [...draft.consequences, ...consequences],
+    aiMetadata: {
+      questionsAsked: questions.length,
+      consequencesAdded: consequences.length,
+      augmentedAt: new Date().toISOString(),
+    },
+  };
+}
+```
+
+## Results
+
+After three months of using AI-augmented ADRs:
+
+- Context sections averaged 4 paragraphs instead of 1
+- Teams revisited decisions 60% less frequently due to confusion
+- New team members could understand past decisions without asking the original author
+
+The AI doesn't make better decisions. It helps you document the decision you already made — with the context you would have forgotten.

--- a/content/blog/neuroscience-of-system-design.mdx
+++ b/content/blog/neuroscience-of-system-design.mdx
@@ -1,0 +1,61 @@
+---
+title: "The Neuroscience of System Design: Why Your Brain Prefers Microservices"
+date: "2026-01-20"
+tags: ["neuroscience", "architecture", "DDD"]
+excerpt: "Our brains chunk information into 7±2 items. Good system architecture does the same thing — and that's not a coincidence."
+published: true
+---
+
+George Miller's 1956 paper "The Magical Number Seven, Plus or Minus Two" described a fundamental constraint of human working memory. We can hold roughly 7 items in our heads at once.
+
+This has profound implications for how we design software systems.
+
+## Working Memory and Bounded Contexts
+
+When an engineer opens a codebase, their working memory starts filling up. Variable names, function signatures, data flows, side effects — each one takes a slot.
+
+A well-designed bounded context keeps the cognitive load within that 7±2 window. You can reason about the entire context without your mental model collapsing.
+
+```typescript
+// This bounded context fits in working memory:
+// 1. Order entity
+// 2. OrderLine value object
+// 3. OrderStatus enum
+// 4. OrderRepository interface
+// 5. PlaceOrder command
+// 6. OrderPlaced event
+// 7. OrderService
+
+// Add one more concept and comprehension drops
+```
+
+A monolith that exposes 50 concepts in a single namespace overwhelms working memory. The brain can't hold the model, so engineers start making assumptions — and assumptions become bugs.
+
+## Chunking and Service Boundaries
+
+Chunking is the brain's strategy for working around the 7±2 limit. We group related items into a single "chunk" that occupies one working memory slot.
+
+This is exactly what microservices do at the system level:
+
+- **Payment Service** — one chunk, regardless of internal complexity
+- **Inventory Service** — one chunk
+- **Notification Service** — one chunk
+
+As long as the interfaces between chunks are clean, an engineer can reason about the system at a high level using just a few working memory slots.
+
+## The Prefrontal Cortex and Abstraction Layers
+
+The prefrontal cortex handles abstract reasoning. It's also the most energy-expensive part of the brain. When we force engineers to reason across too many abstraction levels simultaneously, we're draining their most expensive cognitive resource.
+
+Good architecture minimizes the number of abstraction levels visible at any point:
+
+- **Infrastructure** — you shouldn't see this when writing business logic
+- **Domain** — this is where you live most of the time
+- **Application** — thin orchestration layer
+- **Presentation** — separate concern entirely
+
+## Implications for Architecture Reviews
+
+Next time you review an architecture, ask: "Can I hold this entire context in my head?" If you can't, the system needs better boundaries. Not because of any technical constraint — because of how human brains work.
+
+The best architectures aren't just technically sound. They're cognitively ergonomic.


### PR DESCRIPTION
## Summary
- "AI-Augmented Architecture Decision Records" — tags: AI, architecture, engineering
- "The Neuroscience of System Design" — tags: neuroscience, architecture, DDD
- Both include TypeScript code blocks, structured sections, realistic content
- 3 posts total across 5 unique tags: AI, DDD, architecture, engineering, neuroscience
- Tag filtering now has meaningful data to demonstrate

## Test plan
- [x] `npm run build` passes — all 3 posts statically generated
- [x] `npm test` passes (32 tests)
- [ ] Reviewer: verify all 3 posts render correctly with code blocks
- [ ] Reviewer: verify tag filtering works across the 5 tags

Closes #9

Generated with [Claude Code](https://claude.com/claude-code)