### PR TITLE
feat: presentation listing and full-featured viewer

### DIFF
--- a/app/presentations/[slug]/page.tsx
+++ b/app/presentations/[slug]/page.tsx
@@ -1,0 +1,44 @@
+import { Suspense } from "react";
+import { notFound } from "next/navigation";
+import {
+  getAllPresentationSlugs,
+  getPresentationBySlug,
+} from "@/lib/presentations";
+import { PresentationViewer } from "@/components/PresentationViewer";
+import type { Metadata } from "next";
+
+interface PageProps {
+  params: Promise<{ slug: string }>;
+}
+
+export async function generateStaticParams() {
+  return getAllPresentationSlugs().map((slug) => ({ slug }));
+}
+
+export async function generateMetadata({
+  params,
+}: PageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const pres = getPresentationBySlug(slug);
+  if (!pres) return {};
+
+  return {
+    title: `${pres.title} | ${pres.event}`,
+    description: pres.description,
+  };
+}
+
+export default async function PresentationPage({ params }: PageProps) {
+  const { slug } = await params;
+  const pres = getPresentationBySlug(slug);
+
+  if (!pres) {
+    notFound();
+  }
+
+  return (
+    <Suspense>
+      <PresentationViewer slides={pres.slides} slug={slug} />
+    </Suspense>
+  );
+}

--- a/app/presentations/page.module.css
+++ b/app/presentations/page.module.css
@@ -1,0 +1,111 @@
+.page {
+  max-width: var(--max-width-narrow);
+  margin: 0 auto;
+  padding: var(--space-2xl) var(--space-lg);
+}
+
+.header {
+  padding-bottom: var(--space-2xl);
+  border-bottom: var(--border-thick);
+  margin-bottom: var(--space-2xl);
+}
+
+.title {
+  font-family: var(--font-mono);
+  font-size: var(--text-2xl);
+  font-weight: var(--weight-black);
+  text-transform: uppercase;
+  margin-bottom: var(--space-sm);
+}
+
+.subtitle {
+  color: var(--color-text-muted);
+  font-size: var(--text-base);
+}
+
+.empty {
+  color: var(--color-text-muted);
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+}
+
+.list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+}
+
+.cardLink {
+  border-bottom: none;
+  display: block;
+}
+
+.cardLink:hover {
+  background-color: transparent;
+  color: inherit;
+}
+
+.card {
+  padding: var(--space-lg);
+  border: var(--border-medium);
+  background-color: var(--color-surface);
+}
+
+.card:hover {
+  background-color: var(--color-surface-hover);
+  border-color: var(--color-text);
+}
+
+.meta {
+  display: flex;
+  gap: var(--space-md);
+  margin-bottom: var(--space-md);
+  flex-wrap: wrap;
+}
+
+.event {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-bold);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  padding: 2px var(--space-sm);
+  border: var(--border-thin);
+}
+
+.date {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+}
+
+.slides {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+}
+
+.cardTitle {
+  font-family: var(--font-mono);
+  font-size: var(--text-lg);
+  font-weight: var(--weight-bold);
+  margin-bottom: var(--space-sm);
+  line-height: var(--leading-tight);
+}
+
+.description {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  line-height: var(--leading-relaxed);
+}
+
+@media (max-width: 768px) {
+  .page {
+    padding: var(--space-lg) var(--space-md);
+  }
+
+  .cardTitle {
+    font-size: var(--text-base);
+  }
+}

--- a/app/presentations/page.test.tsx
+++ b/app/presentations/page.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from "@testing-library/react";
+import PresentationsPage from "./page";
+
+jest.mock("next/link", () => {
+  return function MockLink({
+    children,
+    href,
+  }: {
+    children: React.ReactNode;
+    href: string;
+  }) {
+    return <a href={href}>{children}</a>;
+  };
+});
+
+describe("PresentationsPage", () => {
+  it("renders the presentations heading", () => {
+    render(<PresentationsPage />);
+    expect(screen.getByText("// presentations")).toBeInTheDocument();
+  });
+
+  it("renders presentation cards", () => {
+    render(<PresentationsPage />);
+    expect(
+      screen.getByText(/Demand-Driven Context/)
+    ).toBeInTheDocument();
+  });
+
+  it("shows event name and slide count", () => {
+    render(<PresentationsPage />);
+    expect(screen.getByText("NDC 2026")).toBeInTheDocument();
+    expect(screen.getByText("10 slides")).toBeInTheDocument();
+  });
+
+  it("links to individual presentations", () => {
+    render(<PresentationsPage />);
+    const link = screen.getByRole("link", {
+      name: /Demand-Driven Context/,
+    });
+    expect(link).toHaveAttribute(
+      "href",
+      "/presentations/demand-driven-context"
+    );
+  });
+});

--- a/app/presentations/page.tsx
+++ b/app/presentations/page.tsx
@@ -1,0 +1,50 @@
+import Link from "next/link";
+import { getAllPresentations } from "@/lib/presentations";
+import styles from "./page.module.css";
+
+export const metadata = {
+  title: "Presentations",
+  description: "Conference talks and presentations on architecture, DDD, and AI.",
+};
+
+export default function PresentationsPage() {
+  const presentations = getAllPresentations();
+
+  return (
+    <div className={styles.page}>
+      <header className={styles.header}>
+        <h1 className={styles.title}>// presentations</h1>
+        <p className={styles.subtitle}>
+          Conference talks and presentations.
+        </p>
+      </header>
+
+      {presentations.length === 0 ? (
+        <p className={styles.empty}>No presentations yet.</p>
+      ) : (
+        <ul className={styles.list}>
+          {presentations.map((pres) => (
+            <li key={pres.slug}>
+              <Link
+                href={`/presentations/${pres.slug}`}
+                className={styles.cardLink}
+              >
+                <article className={styles.card}>
+                  <div className={styles.meta}>
+                    <span className={styles.event}>{pres.event}</span>
+                    <time className={styles.date}>{pres.date}</time>
+                    <span className={styles.slides}>
+                      {pres.slideCount} slides
+                    </span>
+                  </div>
+                  <h2 className={styles.cardTitle}>{pres.title}</h2>
+                  <p className={styles.description}>{pres.description}</p>
+                </article>
+              </Link>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/components/PresentationViewer.module.css
+++ b/components/PresentationViewer.module.css
@@ -1,0 +1,153 @@
+.viewer {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  min-height: calc(100vh - 80px);
+  background-color: var(--color-bg);
+}
+
+.fullscreen {
+  min-height: 100vh;
+}
+
+/* === Slide Container === */
+.slideContainer {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  max-width: var(--max-width);
+  margin: 0 auto;
+  width: 100%;
+}
+
+/* === Speaker Notes === */
+.notesPanel {
+  border-top: var(--border-medium);
+  background-color: var(--color-bg-secondary);
+  padding: var(--space-md) var(--space-lg);
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.notesTitle {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-bold);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--color-text-muted);
+  margin-bottom: var(--space-sm);
+}
+
+.notesText {
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  line-height: var(--leading-relaxed);
+}
+
+/* === Controls === */
+.controls {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-md);
+  padding: var(--space-sm) var(--space-lg);
+  border-top: var(--border-thin);
+}
+
+.navButton {
+  font-family: var(--font-mono);
+  font-size: var(--text-lg);
+  font-weight: var(--weight-bold);
+  background: none;
+  border: none;
+  color: var(--color-text);
+  padding: var(--space-xs) var(--space-sm);
+  cursor: pointer;
+}
+
+.navButton:hover:not(:disabled) {
+  background-color: var(--color-text);
+  color: var(--color-bg);
+}
+
+.navButton:disabled {
+  color: var(--color-border-muted);
+  cursor: default;
+}
+
+.counter {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-bold);
+  color: var(--color-text-muted);
+  min-width: 60px;
+  text-align: center;
+}
+
+.controlButton {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-bold);
+  background: none;
+  border: none;
+  color: var(--color-text-muted);
+  padding: var(--space-xs) var(--space-sm);
+  cursor: pointer;
+}
+
+.controlButton:hover {
+  background-color: var(--color-text);
+  color: var(--color-bg);
+}
+
+/* === Progress Bar === */
+.progressBar {
+  height: 2px;
+  background-color: var(--color-border-muted);
+}
+
+.progressFill {
+  height: 100%;
+  background-color: var(--color-text);
+  transition: width 0.2s ease;
+}
+
+/* === Fullscreen === */
+.fullscreen .controls {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background-color: var(--color-bg);
+  z-index: 10;
+}
+
+.fullscreen .progressBar {
+  position: fixed;
+  bottom: 44px;
+  left: 0;
+  right: 0;
+  z-index: 10;
+}
+
+.fullscreen .notesPanel {
+  position: fixed;
+  bottom: 46px;
+  left: 0;
+  right: 0;
+  z-index: 10;
+}
+
+/* === Mobile === */
+@media (max-width: 768px) {
+  .controls {
+    gap: var(--space-sm);
+    padding: var(--space-xs) var(--space-md);
+  }
+
+  .counter {
+    font-size: var(--text-xs);
+  }
+}

--- a/components/PresentationViewer.test.tsx
+++ b/components/PresentationViewer.test.tsx
@@ -1,0 +1,133 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { PresentationViewer } from "./PresentationViewer";
+import type { Slide } from "@/lib/presentations";
+
+const mockSlides: Slide[] = [
+  {
+    type: "title",
+    title: "Test Presentation",
+    subtitle: "A subtitle",
+    notes: "Speaker note for slide 1",
+  },
+  {
+    type: "bullets",
+    title: "Bullet Points",
+    items: ["Item one", "Item two"],
+    notes: "Speaker note for slide 2",
+  },
+  {
+    type: "code",
+    title: "Code Example",
+    language: "typescript",
+    code: "const x = 1;",
+  },
+];
+
+let mockSearchParams = new URLSearchParams();
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({
+    replace: jest.fn(),
+  }),
+  useSearchParams: () => mockSearchParams,
+}));
+
+describe("PresentationViewer", () => {
+  beforeEach(() => {
+    mockSearchParams = new URLSearchParams();
+  });
+
+  it("renders the first slide by default", () => {
+    render(<PresentationViewer slides={mockSlides} slug="test" />);
+    expect(screen.getByText("Test Presentation")).toBeInTheDocument();
+  });
+
+  it("shows slide counter", () => {
+    render(<PresentationViewer slides={mockSlides} slug="test" />);
+    expect(screen.getByText("1 / 3")).toBeInTheDocument();
+  });
+
+  it("navigates to next slide on button click", async () => {
+    const user = userEvent.setup();
+    render(<PresentationViewer slides={mockSlides} slug="test" />);
+
+    await user.click(screen.getByRole("button", { name: /next slide/i }));
+    expect(screen.getByText("Bullet Points")).toBeInTheDocument();
+    expect(screen.getByText("2 / 3")).toBeInTheDocument();
+  });
+
+  it("navigates with arrow keys", async () => {
+    const user = userEvent.setup();
+    render(<PresentationViewer slides={mockSlides} slug="test" />);
+
+    await user.keyboard("{ArrowRight}");
+    expect(screen.getByText("Bullet Points")).toBeInTheDocument();
+
+    await user.keyboard("{ArrowLeft}");
+    expect(screen.getByText("Test Presentation")).toBeInTheDocument();
+  });
+
+  it("disables previous button on first slide", () => {
+    render(<PresentationViewer slides={mockSlides} slug="test" />);
+    const prevBtn = screen.getByRole("button", { name: /previous slide/i });
+    expect(prevBtn).toBeDisabled();
+  });
+
+  it("toggles speaker notes with N key", async () => {
+    const user = userEvent.setup();
+    render(<PresentationViewer slides={mockSlides} slug="test" />);
+
+    expect(
+      screen.queryByText("Speaker note for slide 1")
+    ).not.toBeInTheDocument();
+
+    await user.keyboard("n");
+    expect(
+      screen.getByText("Speaker note for slide 1")
+    ).toBeInTheDocument();
+
+    await user.keyboard("n");
+    expect(
+      screen.queryByText("Speaker note for slide 1")
+    ).not.toBeInTheDocument();
+  });
+
+  it("toggles speaker notes with button click", async () => {
+    const user = userEvent.setup();
+    render(<PresentationViewer slides={mockSlides} slug="test" />);
+
+    await user.click(
+      screen.getByRole("button", { name: /show speaker notes/i })
+    );
+    expect(
+      screen.getByText("Speaker note for slide 1")
+    ).toBeInTheDocument();
+  });
+
+  it("shows progress bar", () => {
+    render(<PresentationViewer slides={mockSlides} slug="test" />);
+    expect(
+      screen.getByRole("progressbar", { name: /slide progress/i })
+    ).toBeInTheDocument();
+  });
+
+  it("starts on deep-linked slide", () => {
+    mockSearchParams = new URLSearchParams("slide=2");
+    render(<PresentationViewer slides={mockSlides} slug="test" />);
+    expect(screen.getByText("Bullet Points")).toBeInTheDocument();
+    expect(screen.getByText("2 / 3")).toBeInTheDocument();
+  });
+
+  it("navigates to first/last slide with Home/End", async () => {
+    const user = userEvent.setup();
+    mockSearchParams = new URLSearchParams("slide=2");
+    render(<PresentationViewer slides={mockSlides} slug="test" />);
+
+    await user.keyboard("{End}");
+    expect(screen.getByText("3 / 3")).toBeInTheDocument();
+
+    await user.keyboard("{Home}");
+    expect(screen.getByText("1 / 3")).toBeInTheDocument();
+  });
+});

--- a/components/PresentationViewer.tsx
+++ b/components/PresentationViewer.tsx
@@ -1,0 +1,226 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import type { Slide } from "@/lib/presentations";
+import { SlideRenderer } from "./SlideRenderer";
+import styles from "./PresentationViewer.module.css";
+
+interface PresentationViewerProps {
+  slides: Slide[];
+  slug: string;
+}
+
+export function PresentationViewer({ slides, slug }: PresentationViewerProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const containerRef = useRef<HTMLDivElement>(null);
+  const touchStartX = useRef<number>(0);
+  const touchStartY = useRef<number>(0);
+
+  const initialSlide = Number(searchParams.get("slide")) || 1;
+  const [currentSlide, setCurrentSlide] = useState(
+    Math.min(Math.max(1, initialSlide), slides.length)
+  );
+  const [showNotes, setShowNotes] = useState(false);
+  const [isFullscreen, setIsFullscreen] = useState(false);
+
+  const totalSlides = slides.length;
+  const slide = slides[currentSlide - 1];
+  const progress = (currentSlide / totalSlides) * 100;
+
+  const goToSlide = useCallback(
+    (n: number) => {
+      const clamped = Math.min(Math.max(1, n), totalSlides);
+      setCurrentSlide(clamped);
+      const url = `/presentations/${slug}?slide=${clamped}`;
+      router.replace(url, { scroll: false });
+    },
+    [totalSlides, slug, router]
+  );
+
+  const next = useCallback(() => goToSlide(currentSlide + 1), [currentSlide, goToSlide]);
+  const prev = useCallback(() => goToSlide(currentSlide - 1), [currentSlide, goToSlide]);
+  const first = useCallback(() => goToSlide(1), [goToSlide]);
+  const last = useCallback(() => goToSlide(totalSlides), [goToSlide, totalSlides]);
+
+  const toggleFullscreen = useCallback(async () => {
+    if (!containerRef.current) return;
+
+    if (!document.fullscreenElement) {
+      await containerRef.current.requestFullscreen();
+      setIsFullscreen(true);
+    } else {
+      await document.exitFullscreen();
+      setIsFullscreen(false);
+    }
+  }, []);
+
+  // Keyboard navigation
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      // Don't capture if user is typing in an input
+      if (
+        e.target instanceof HTMLInputElement ||
+        e.target instanceof HTMLTextAreaElement
+      ) {
+        return;
+      }
+
+      switch (e.key) {
+        case "ArrowRight":
+        case "ArrowDown":
+          e.preventDefault();
+          next();
+          break;
+        case "ArrowLeft":
+        case "ArrowUp":
+          e.preventDefault();
+          prev();
+          break;
+        case "Home":
+          e.preventDefault();
+          first();
+          break;
+        case "End":
+          e.preventDefault();
+          last();
+          break;
+        case "f":
+        case "Enter":
+          e.preventDefault();
+          toggleFullscreen();
+          break;
+        case "Escape":
+          if (document.fullscreenElement) {
+            document.exitFullscreen();
+            setIsFullscreen(false);
+          }
+          break;
+        case "n":
+        case "N":
+          e.preventDefault();
+          setShowNotes((prev) => !prev);
+          break;
+      }
+    }
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [next, prev, first, last, toggleFullscreen]);
+
+  // Fullscreen change listener
+  useEffect(() => {
+    function handleFullscreenChange() {
+      setIsFullscreen(!!document.fullscreenElement);
+    }
+
+    document.addEventListener("fullscreenchange", handleFullscreenChange);
+    return () =>
+      document.removeEventListener("fullscreenchange", handleFullscreenChange);
+  }, []);
+
+  // Touch/swipe navigation
+  const handleTouchStart = useCallback((e: React.TouchEvent) => {
+    touchStartX.current = e.touches[0].clientX;
+    touchStartY.current = e.touches[0].clientY;
+  }, []);
+
+  const handleTouchEnd = useCallback(
+    (e: React.TouchEvent) => {
+      const deltaX = e.changedTouches[0].clientX - touchStartX.current;
+      const deltaY = e.changedTouches[0].clientY - touchStartY.current;
+      const minSwipe = 50;
+
+      // Only horizontal swipes (ignore vertical scroll)
+      if (Math.abs(deltaX) > Math.abs(deltaY) && Math.abs(deltaX) > minSwipe) {
+        if (deltaX < 0) {
+          next();
+        } else {
+          prev();
+        }
+      }
+    },
+    [next, prev]
+  );
+
+  const notes = "notes" in slide ? slide.notes : undefined;
+
+  return (
+    <div
+      ref={containerRef}
+      className={`${styles.viewer} ${isFullscreen ? styles.fullscreen : ""}`}
+      onTouchStart={handleTouchStart}
+      onTouchEnd={handleTouchEnd}
+    >
+      <div className={styles.slideContainer}>
+        <SlideRenderer slide={slide} />
+      </div>
+
+      {/* Speaker Notes */}
+      {showNotes && notes && (
+        <div className={styles.notesPanel} aria-label="Speaker notes">
+          <h3 className={styles.notesTitle}>// notes</h3>
+          <p className={styles.notesText}>{notes}</p>
+        </div>
+      )}
+
+      {/* Controls */}
+      <div className={styles.controls}>
+        <button
+          className={styles.navButton}
+          onClick={prev}
+          disabled={currentSlide === 1}
+          aria-label="Previous slide"
+        >
+          &larr;
+        </button>
+
+        <span className={styles.counter} aria-live="polite">
+          {currentSlide} / {totalSlides}
+        </span>
+
+        <button
+          className={styles.navButton}
+          onClick={next}
+          disabled={currentSlide === totalSlides}
+          aria-label="Next slide"
+        >
+          &rarr;
+        </button>
+
+        <button
+          className={styles.controlButton}
+          onClick={() => setShowNotes(!showNotes)}
+          aria-label={showNotes ? "Hide speaker notes" : "Show speaker notes"}
+          aria-pressed={showNotes}
+        >
+          [N]
+        </button>
+
+        <button
+          className={styles.controlButton}
+          onClick={toggleFullscreen}
+          aria-label={isFullscreen ? "Exit fullscreen" : "Enter fullscreen"}
+        >
+          {isFullscreen ? "[X]" : "[F]"}
+        </button>
+      </div>
+
+      {/* Progress Bar */}
+      <div
+        className={styles.progressBar}
+        role="progressbar"
+        aria-valuenow={currentSlide}
+        aria-valuemin={1}
+        aria-valuemax={totalSlides}
+        aria-label="Slide progress"
+      >
+        <div
+          className={styles.progressFill}
+          style={{ width: `${progress}%` }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/components/SlideRenderer.module.css
+++ b/components/SlideRenderer.module.css
@@ -1,0 +1,227 @@
+/* === Base Slide === */
+.slide {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+  width: 100%;
+  height: 100%;
+  padding: var(--space-2xl) var(--space-3xl);
+}
+
+.heading {
+  font-family: var(--font-mono);
+  font-size: var(--text-2xl);
+  font-weight: var(--weight-bold);
+  margin-bottom: var(--space-xl);
+  text-transform: uppercase;
+  letter-spacing: -0.02em;
+}
+
+/* === Title Slide === */
+.titleSlide {
+  align-items: center;
+  text-align: center;
+}
+
+.titleMain {
+  font-family: var(--font-mono);
+  font-size: var(--text-3xl);
+  font-weight: var(--weight-black);
+  text-transform: uppercase;
+  letter-spacing: -0.03em;
+  line-height: 1;
+  margin-bottom: var(--space-md);
+}
+
+.titleSub {
+  font-size: var(--text-lg);
+  color: var(--color-text-secondary);
+  margin-bottom: var(--space-xl);
+  max-width: 600px;
+}
+
+.titleMeta {
+  display: flex;
+  gap: var(--space-lg);
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+}
+
+.author,
+.event,
+.date {
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+/* === Section Slide === */
+.sectionSlide {
+  align-items: center;
+  text-align: center;
+}
+
+.sectionTitle {
+  font-family: var(--font-mono);
+  font-size: var(--text-3xl);
+  font-weight: var(--weight-black);
+  text-transform: uppercase;
+  letter-spacing: -0.03em;
+}
+
+.sectionSub {
+  font-size: var(--text-lg);
+  color: var(--color-text-muted);
+  margin-top: var(--space-md);
+}
+
+/* === Content Slide === */
+.body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+  font-size: var(--text-lg);
+  line-height: var(--leading-relaxed);
+  color: var(--color-text-secondary);
+  max-width: 700px;
+}
+
+/* === Bullets Slide === */
+.bulletList {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.bulletItem {
+  font-size: var(--text-lg);
+  color: var(--color-text-secondary);
+  padding-left: var(--space-lg);
+  position: relative;
+}
+
+.bulletItem::before {
+  content: ">";
+  position: absolute;
+  left: 0;
+  font-family: var(--font-mono);
+  color: var(--color-text-muted);
+  font-weight: var(--weight-bold);
+}
+
+/* === Code Slide === */
+.codeBlock {
+  width: 100%;
+  max-width: 700px;
+  background-color: var(--color-bg-secondary);
+  border: var(--border-medium);
+  padding: var(--space-lg);
+  overflow-x: auto;
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  line-height: var(--leading-normal);
+}
+
+.codeBlock code {
+  background: none;
+  padding: 0;
+}
+
+.caption {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  margin-top: var(--space-md);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+/* === Image Slide === */
+.imageWrapper {
+  display: flex;
+  justify-content: center;
+  width: 100%;
+}
+
+.image {
+  max-width: 100%;
+  max-height: 60vh;
+  border: var(--border-medium);
+}
+
+/* === Two Column Slide === */
+.columns {
+  display: flex;
+  gap: var(--space-xl);
+  width: 100%;
+}
+
+.column {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.columnDivider {
+  width: 2px;
+  background-color: var(--color-border-muted);
+  flex-shrink: 0;
+}
+
+.colHeader {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-black);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  margin-bottom: var(--space-sm);
+  padding-bottom: var(--space-sm);
+  border-bottom: var(--border-thin);
+}
+
+.colItem {
+  font-size: var(--text-base);
+  color: var(--color-text-secondary);
+}
+
+/* === Mobile === */
+@media (max-width: 768px) {
+  .slide {
+    padding: var(--space-lg) var(--space-md);
+  }
+
+  .titleMain {
+    font-size: var(--text-2xl);
+  }
+
+  .sectionTitle {
+    font-size: var(--text-2xl);
+  }
+
+  .heading {
+    font-size: var(--text-xl);
+  }
+
+  .body,
+  .bulletItem,
+  .colItem {
+    font-size: var(--text-base);
+  }
+
+  .columns {
+    flex-direction: column;
+  }
+
+  .columnDivider {
+    width: 100%;
+    height: 2px;
+  }
+
+  .codeBlock {
+    font-size: var(--text-xs);
+    padding: var(--space-md);
+  }
+}

--- a/components/SlideRenderer.tsx
+++ b/components/SlideRenderer.tsx
@@ -1,0 +1,120 @@
+import type { Slide } from "@/lib/presentations";
+import styles from "./SlideRenderer.module.css";
+
+interface SlideRendererProps {
+  slide: Slide;
+}
+
+export function SlideRenderer({ slide }: SlideRendererProps) {
+  switch (slide.type) {
+    case "title":
+      return (
+        <div className={`${styles.slide} ${styles.titleSlide}`}>
+          <h1 className={styles.titleMain}>{slide.title}</h1>
+          {slide.subtitle && (
+            <p className={styles.titleSub}>{slide.subtitle}</p>
+          )}
+          {(slide.author || slide.event) && (
+            <div className={styles.titleMeta}>
+              {slide.author && (
+                <span className={styles.author}>{slide.author}</span>
+              )}
+              {slide.event && (
+                <span className={styles.event}>{slide.event}</span>
+              )}
+              {slide.date && (
+                <span className={styles.date}>{slide.date}</span>
+              )}
+            </div>
+          )}
+        </div>
+      );
+
+    case "section":
+      return (
+        <div className={`${styles.slide} ${styles.sectionSlide}`}>
+          <h2 className={styles.sectionTitle}>{slide.title}</h2>
+          {slide.subtitle && (
+            <p className={styles.sectionSub}>{slide.subtitle}</p>
+          )}
+        </div>
+      );
+
+    case "content":
+      return (
+        <div className={`${styles.slide} ${styles.contentSlide}`}>
+          <h2 className={styles.heading}>{slide.title}</h2>
+          <div className={styles.body}>
+            {slide.body.map((paragraph, i) => (
+              <p key={i}>{paragraph}</p>
+            ))}
+          </div>
+        </div>
+      );
+
+    case "bullets":
+      return (
+        <div className={`${styles.slide} ${styles.bulletsSlide}`}>
+          <h2 className={styles.heading}>{slide.title}</h2>
+          <ul className={styles.bulletList}>
+            {slide.items.map((item, i) => (
+              <li key={i} className={styles.bulletItem}>
+                {item}
+              </li>
+            ))}
+          </ul>
+        </div>
+      );
+
+    case "code":
+      return (
+        <div className={`${styles.slide} ${styles.codeSlide}`}>
+          <h2 className={styles.heading}>{slide.title}</h2>
+          <pre className={styles.codeBlock}>
+            <code>{slide.code}</code>
+          </pre>
+          {slide.caption && (
+            <p className={styles.caption}>{slide.caption}</p>
+          )}
+        </div>
+      );
+
+    case "image":
+      return (
+        <div className={`${styles.slide} ${styles.imageSlide}`}>
+          <h2 className={styles.heading}>{slide.title}</h2>
+          <div className={styles.imageWrapper}>
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img src={slide.src} alt={slide.alt} className={styles.image} />
+          </div>
+          {slide.caption && (
+            <p className={styles.caption}>{slide.caption}</p>
+          )}
+        </div>
+      );
+
+    case "two-column":
+      return (
+        <div className={`${styles.slide} ${styles.twoColSlide}`}>
+          <h2 className={styles.heading}>{slide.title}</h2>
+          <div className={styles.columns}>
+            <div className={styles.column}>
+              {slide.left.map((item, i) => (
+                <p key={i} className={i === 0 ? styles.colHeader : styles.colItem}>
+                  {item}
+                </p>
+              ))}
+            </div>
+            <div className={styles.columnDivider} />
+            <div className={styles.column}>
+              {slide.right.map((item, i) => (
+                <p key={i} className={i === 0 ? styles.colHeader : styles.colItem}>
+                  {item}
+                </p>
+              ))}
+            </div>
+          </div>
+        </div>
+      );
+  }
+}


### PR DESCRIPTION
## Summary
- `/presentations` — listing page with card layout (title, event, date, slide count)
- `/presentations/[slug]` — full presentation viewer
- **Keyboard navigation**: arrows (left/right, up/down), Home/End for first/last
- **Fullscreen**: F/Enter to toggle, Escape to exit, Fullscreen API
- **Deep-linking**: URL updates with `?slide=N`, direct navigation via URL
- **Touch/swipe**: horizontal swipe for mobile, ignores vertical scroll
- **Speaker notes**: toggle with N key or [N] button, panel below slide
- **Progress bar**: thin bar at bottom showing position
- **Slide counter**: "3 / 10" display
- `SlideRenderer` supports all 7 types: title, section, content, bullets, code, image, two-column

## Test plan
- [x] `npm run build` passes — all routes statically generated
- [x] `npm test` passes (52 tests, 14 new)
- [ ] Reviewer: navigate through slides with arrow keys
- [ ] Reviewer: test fullscreen toggle with F key
- [ ] Reviewer: test deep-link: `/presentations/demand-driven-context?slide=5`
- [ ] Reviewer: toggle speaker notes with N key
- [ ] Reviewer: test on mobile viewport (swipe navigation)

Closes #11, #12, #13, #14, #15, #16

Generated with [Claude Code](https://claude.com/claude-code)