### PR TITLE
feat: SEO, sitemap, robots.txt, and JSON-LD

### DIFF
--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -20,9 +20,19 @@ export async function generateMetadata({
   const post = getPostBySlug(slug);
   if (!post) return {};
 
+  const url = `https://rajnavakoti.dev/blog/${slug}`;
+
   return {
     title: post.frontmatter.title,
     description: post.frontmatter.excerpt,
+    openGraph: {
+      type: "article",
+      title: post.frontmatter.title,
+      description: post.frontmatter.excerpt,
+      url,
+      publishedTime: post.frontmatter.date,
+      tags: post.frontmatter.tags,
+    },
   };
 }
 
@@ -39,8 +49,25 @@ export default async function BlogPostPage({ params }: PageProps) {
     options: { parseFrontmatter: false },
   });
 
+  const jsonLd = {
+    "@context": "https://schema.org",
+    "@type": "BlogPosting",
+    headline: post.frontmatter.title,
+    description: post.frontmatter.excerpt,
+    datePublished: post.frontmatter.date,
+    author: {
+      "@type": "Person",
+      name: "Raj Navakoti",
+    },
+    keywords: post.frontmatter.tags.join(", "),
+  };
+
   return (
     <article className={styles.article}>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
       <header className={styles.header}>
         <div className={styles.meta}>
           <time className={styles.date}>{post.frontmatter.date}</time>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -12,6 +12,8 @@ const jetbrainsMono = JetBrains_Mono({
   display: "swap",
 });
 
+const siteUrl = "https://rajnavakoti.dev";
+
 export const metadata: Metadata = {
   title: {
     default: "Raj Navakoti",
@@ -19,6 +21,26 @@ export const metadata: Metadata = {
   },
   description:
     "Staff Software Engineer - AI, neuroscience, enterprise architecture, DDD",
+  metadataBase: new URL(siteUrl),
+  openGraph: {
+    type: "website",
+    locale: "en_US",
+    url: siteUrl,
+    siteName: "Raj Navakoti",
+    title: "Raj Navakoti",
+    description:
+      "Staff Software Engineer - AI, neuroscience, enterprise architecture, DDD",
+  },
+  twitter: {
+    card: "summary",
+    title: "Raj Navakoti",
+    description:
+      "Staff Software Engineer - AI, neuroscience, enterprise architecture, DDD",
+  },
+  robots: {
+    index: true,
+    follow: true,
+  },
 };
 
 export default function RootLayout({

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,13 @@
+import type { MetadataRoute } from "next";
+
+export const dynamic = "force-static";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+    },
+    sitemap: "https://rajnavakoti.dev/sitemap.xml",
+  };
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,52 @@
+import type { MetadataRoute } from "next";
+
+export const dynamic = "force-static";
+
+import { getAllSlugs } from "@/lib/blog";
+import { getAllPresentationSlugs } from "@/lib/presentations";
+
+const siteUrl = "https://rajnavakoti.dev";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const blogSlugs = getAllSlugs();
+  const presentationSlugs = getAllPresentationSlugs();
+
+  const staticPages: MetadataRoute.Sitemap = [
+    {
+      url: siteUrl,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 1,
+    },
+    {
+      url: `${siteUrl}/blog`,
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 0.8,
+    },
+    {
+      url: `${siteUrl}/presentations`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.8,
+    },
+  ];
+
+  const blogPages: MetadataRoute.Sitemap = blogSlugs.map((slug) => ({
+    url: `${siteUrl}/blog/${slug}`,
+    lastModified: new Date(),
+    changeFrequency: "monthly" as const,
+    priority: 0.6,
+  }));
+
+  const presentationPages: MetadataRoute.Sitemap = presentationSlugs.map(
+    (slug) => ({
+      url: `${siteUrl}/presentations/${slug}`,
+      lastModified: new Date(),
+      changeFrequency: "monthly" as const,
+      priority: 0.6,
+    })
+  );
+
+  return [...staticPages, ...blogPages, ...presentationPages];
+}


### PR DESCRIPTION
## Summary
- Root layout: OpenGraph + Twitter meta tags, `metadataBase` for absolute URLs
- Blog posts: OG `article` type with published time and tags, JSON-LD `BlogPosting` structured data
- Auto-generated `sitemap.xml` covering all static pages, blog posts, and presentations
- `robots.txt` allowing all crawlers with sitemap reference
- All pages already use semantic HTML, ARIA labels, skip-to-content, keyboard navigation

### Accessibility (already in place from prior PRs)
- Skip-to-content link
- Semantic HTML throughout (nav, main, article, section, footer)
- ARIA labels on all interactive elements
- Keyboard navigable (header, blog, presentation viewer)
- `aria-current="page"` on active nav link
- `aria-pressed` on tag filters and theme toggle
- `aria-live="polite"` on slide counter

### Performance (already in place)
- Static export (all pages pre-rendered)
- Font display: swap (no FOIT)
- No unnecessary JS (only interactive components are client-side)
- CSS Modules for zero-runtime styling

## Test plan
- [x] `npm run build` passes — sitemap.xml and robots.txt generated
- [x] `npm test` passes (52 tests)
- [ ] Reviewer: check `/sitemap.xml` lists all pages
- [ ] Reviewer: check `/robots.txt` content
- [ ] Reviewer: inspect blog post source for JSON-LD script tag

Closes #18, #19, #20

Generated with [Claude Code](https://claude.com/claude-code)