### PR TITLE
feat: redesign home page with terminal/retro-OS windowed aesthetic

### DIFF
--- a/app/page.module.css
+++ b/app/page.module.css
@@ -2,21 +2,64 @@
   max-width: var(--max-width-narrow);
   margin: 0 auto;
   padding: var(--space-2xl) var(--space-lg);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xl);
 }
 
-/* === Hero === */
+/* ============================================
+   HERO — Terminal Window
+   ============================================ */
 .hero {
-  padding: var(--space-4xl) 0 var(--space-3xl);
+  padding-top: var(--space-2xl);
+}
+
+.terminal {
+  border: var(--border-thick);
+  overflow: hidden;
+}
+
+.terminalBar {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  padding: var(--space-sm) var(--space-md);
+  background-color: var(--color-text);
+  color: var(--color-bg);
   border-bottom: var(--border-thick);
 }
 
-.greeting {
+.terminalDot {
+  width: 12px;
+  height: 12px;
+  border: 2px solid var(--color-bg);
+  display: inline-block;
+}
+
+.terminalTitle {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-bold);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  margin-left: var(--space-sm);
+}
+
+.terminalBody {
+  padding: var(--space-xl) var(--space-lg);
+  background-color: var(--color-bg);
+}
+
+.prompt {
   font-family: var(--font-mono);
   font-size: var(--text-sm);
   color: var(--color-text-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.15em;
-  margin-bottom: var(--space-sm);
+  margin-bottom: var(--space-lg);
+}
+
+.promptSymbol {
+  color: var(--color-text);
+  font-weight: var(--weight-bold);
 }
 
 .name {
@@ -25,54 +68,94 @@
   text-transform: uppercase;
   letter-spacing: -0.03em;
   line-height: 1;
-  margin-bottom: var(--space-sm);
+  margin-bottom: var(--space-xs);
 }
 
 .title {
   font-family: var(--font-mono);
   font-size: var(--text-lg);
   font-weight: var(--weight-bold);
-  margin-bottom: var(--space-lg);
+  color: var(--color-text-secondary);
+  margin-bottom: var(--space-md);
 }
 
 .tagline {
-  font-size: var(--text-lg);
-  color: var(--color-text-secondary);
-  max-width: 600px;
-  line-height: var(--leading-relaxed);
+  font-family: var(--font-mono);
+  font-size: var(--text-base);
+  color: var(--color-text-muted);
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
 }
 
-/* === Sections === */
-.section {
-  padding: var(--space-2xl) 0;
-  border-bottom: var(--border-muted);
-}
-
-.sectionTitle {
+.cursor {
   font-family: var(--font-mono);
   font-size: var(--text-sm);
+  margin-top: var(--space-xl);
+}
+
+.blink {
+  animation: blink 1s step-end infinite;
+}
+
+@keyframes blink {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0;
+  }
+}
+
+/* ============================================
+   WINDOW PANELS — Retro OS style
+   ============================================ */
+.window {
+  border: var(--border-medium);
+  overflow: hidden;
+}
+
+.windowBar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-sm) var(--space-md);
+  background-color: var(--color-bg-secondary);
+  border-bottom: var(--border-medium);
+}
+
+.windowLabel {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
   font-weight: var(--weight-bold);
   text-transform: uppercase;
   letter-spacing: 0.1em;
+}
+
+.windowControls {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
   color: var(--color-text-muted);
-  margin-bottom: var(--space-xl);
+  letter-spacing: 0.05em;
 }
 
-/* === About === */
-.aboutContent {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-md);
+.windowBody {
+  padding: var(--space-lg);
 }
 
-.paragraph {
+/* ============================================
+   ABOUT
+   ============================================ */
+.aboutText {
   font-size: var(--text-base);
   color: var(--color-text-secondary);
   line-height: var(--leading-relaxed);
-  max-width: 65ch;
+  max-width: 60ch;
 }
 
-/* === Current Focus === */
+/* ============================================
+   FOCUS
+   ============================================ */
 .focusList {
   list-style: none;
   display: flex;
@@ -88,44 +171,50 @@
   gap: var(--space-sm);
 }
 
-.bullet {
+.focusBullet {
   color: var(--color-text-muted);
   flex-shrink: 0;
+  font-weight: var(--weight-bold);
 }
 
-/* === Speaking === */
-.speakingGroup {
-  margin-bottom: var(--space-xl);
+/* ============================================
+   SPEAKING
+   ============================================ */
+.talkGroup {
+  margin-bottom: var(--space-lg);
 }
 
-.speakingGroup:last-child {
+.talkGroup:last-child {
   margin-bottom: 0;
 }
 
-.speakingLabel {
+.talkGroupLabel {
   font-family: var(--font-mono);
   font-size: var(--text-xs);
-  font-weight: var(--weight-bold);
-  text-transform: uppercase;
-  letter-spacing: 0.15em;
   color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
   margin-bottom: var(--space-md);
-}
-
-.engagements {
-  display: flex;
-  flex-direction: column;
-  gap: var(--space-md);
 }
 
 .talkCard {
   padding: var(--space-md);
   border: var(--border-thin);
-  background-color: var(--color-surface);
+  margin-bottom: var(--space-sm);
+}
+
+.talkCard:last-child {
+  margin-bottom: 0;
 }
 
 .talkCard:hover {
-  background-color: var(--color-surface-hover);
+  background-color: var(--color-text);
+  color: var(--color-bg);
+}
+
+.talkCard:hover .talkMeta {
+  color: var(--color-bg);
+  opacity: 0.7;
 }
 
 .talkTitle {
@@ -136,11 +225,14 @@
 }
 
 .talkMeta {
+  font-family: var(--font-mono);
   font-size: var(--text-xs);
   color: var(--color-text-muted);
 }
 
-/* === Connect === */
+/* ============================================
+   CONNECT
+   ============================================ */
 .linkGrid {
   display: flex;
   gap: var(--space-md);
@@ -152,10 +244,9 @@
   font-size: var(--text-sm);
   font-weight: var(--weight-bold);
   text-transform: uppercase;
-  letter-spacing: 0.05em;
-  padding: var(--space-sm) var(--space-md);
+  letter-spacing: 0.08em;
+  padding: var(--space-sm) var(--space-lg);
   border: var(--border-medium);
-  border-bottom: var(--border-medium);
   background-color: var(--color-bg);
 }
 
@@ -164,25 +255,44 @@
   color: var(--color-bg);
 }
 
-.arrow {
-  display: inline;
-}
-
-/* === Mobile === */
+/* ============================================
+   MOBILE
+   ============================================ */
 @media (max-width: 768px) {
   .page {
     padding: var(--space-lg) var(--space-md);
+    gap: var(--space-lg);
   }
 
   .hero {
-    padding: var(--space-2xl) 0 var(--space-xl);
+    padding-top: var(--space-lg);
+  }
+
+  .terminalBody {
+    padding: var(--space-lg) var(--space-md);
   }
 
   .name {
     font-size: var(--text-2xl);
   }
 
-  .tagline {
+  .title {
     font-size: var(--text-base);
+  }
+
+  .tagline {
+    font-size: var(--text-sm);
+  }
+
+  .windowBody {
+    padding: var(--space-md);
+  }
+
+  .linkGrid {
+    flex-direction: column;
+  }
+
+  .connectLink {
+    text-align: center;
   }
 }

--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -2,35 +2,42 @@ import { render, screen } from "@testing-library/react";
 import Home from "./page";
 
 describe("Home", () => {
-  it("renders the hero section with name and title", () => {
+  it("renders the terminal hero with name and title", () => {
     render(<Home />);
     expect(screen.getByText("Raj Navakoti")).toBeInTheDocument();
     expect(screen.getByText("Staff Software Engineer")).toBeInTheDocument();
   });
 
-  it("renders about section", () => {
+  it("renders terminal prompt elements", () => {
     render(<Home />);
-    expect(screen.getByText("// about")).toBeInTheDocument();
+    expect(screen.getByText(/whoami/)).toBeInTheDocument();
+    expect(screen.getByText("~/raj")).toBeInTheDocument();
   });
 
-  it("renders current focus items", () => {
+  it("renders about window panel", () => {
     render(<Home />);
-    expect(screen.getByText("// current focus")).toBeInTheDocument();
+    expect(screen.getByText("ABOUT.md")).toBeInTheDocument();
+    expect(screen.getByText(/intersection of software/)).toBeInTheDocument();
+  });
+
+  it("renders focus window with items", () => {
+    render(<Home />);
+    expect(screen.getByText("FOCUS.log")).toBeInTheDocument();
     expect(
       screen.getByText(/Demand-Driven Context framework/)
     ).toBeInTheDocument();
   });
 
-  it("renders speaking engagements", () => {
+  it("renders speaking window with talks", () => {
     render(<Home />);
-    expect(screen.getByText("// speaking")).toBeInTheDocument();
-    expect(screen.getByText("Upcoming")).toBeInTheDocument();
-    expect(screen.getByText("Past")).toBeInTheDocument();
+    expect(screen.getByText("TALKS.json")).toBeInTheDocument();
+    expect(screen.getByText("// upcoming")).toBeInTheDocument();
+    expect(screen.getByText("// past")).toBeInTheDocument();
   });
 
-  it("renders connect links", () => {
+  it("renders connect window with links", () => {
     render(<Home />);
-    expect(screen.getByText("// connect")).toBeInTheDocument();
+    expect(screen.getByText("LINKS.sh")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /GitHub/ })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /LinkedIn/ })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Email/ })).toBeInTheDocument();

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,102 +7,147 @@ export default function Home() {
 
   return (
     <div className={styles.page}>
+      {/* Hero — terminal style */}
       <section className={styles.hero}>
-        <p className={styles.greeting}>Hello, I&apos;m</p>
-        <h1 className={styles.name}>{profile.name}</h1>
-        <p className={styles.title}>{profile.title}</p>
-        <p className={styles.tagline}>{profile.tagline}</p>
-      </section>
-
-      <section className={styles.section} aria-labelledby="about-heading">
-        <h2 id="about-heading" className={styles.sectionTitle}>
-          // about
-        </h2>
-        <div className={styles.aboutContent}>
-          {profile.about.map((paragraph, i) => (
-            <p key={i} className={styles.paragraph}>
-              {paragraph}
+        <div className={styles.terminal}>
+          <div className={styles.terminalBar}>
+            <span className={styles.terminalDot} aria-hidden="true" />
+            <span className={styles.terminalDot} aria-hidden="true" />
+            <span className={styles.terminalDot} aria-hidden="true" />
+            <span className={styles.terminalTitle}>~/raj</span>
+          </div>
+          <div className={styles.terminalBody}>
+            <p className={styles.prompt}>
+              <span className={styles.promptSymbol} aria-hidden="true">
+                $
+              </span>{" "}
+              whoami
             </p>
-          ))}
+            <h1 className={styles.name}>{profile.name}</h1>
+            <p className={styles.title}>{profile.title}</p>
+            <p className={styles.tagline}>{profile.tagline}</p>
+            <p className={styles.cursor} aria-hidden="true">
+              <span className={styles.promptSymbol}>$</span>{" "}
+              <span className={styles.blink}>_</span>
+            </p>
+          </div>
         </div>
       </section>
 
-      <section className={styles.section} aria-labelledby="focus-heading">
-        <h2 id="focus-heading" className={styles.sectionTitle}>
-          // current focus
-        </h2>
-        <ul className={styles.focusList}>
-          {profile.currentFocus.map((item) => (
-            <li key={item} className={styles.focusItem}>
-              <span className={styles.bullet} aria-hidden="true">
-                &gt;
-              </span>
-              {item}
-            </li>
-          ))}
-        </ul>
+      {/* About — window panel */}
+      <section aria-labelledby="about-heading">
+        <div className={styles.window}>
+          <div className={styles.windowBar}>
+            <span className={styles.windowLabel} id="about-heading">
+              ABOUT.md
+            </span>
+            <span className={styles.windowControls} aria-hidden="true">
+              [&minus;] [&square;] [&times;]
+            </span>
+          </div>
+          <div className={styles.windowBody}>
+            <p className={styles.aboutText}>{profile.about}</p>
+          </div>
+        </div>
       </section>
 
-      <section className={styles.section} aria-labelledby="speaking-heading">
-        <h2 id="speaking-heading" className={styles.sectionTitle}>
-          // speaking
-        </h2>
+      {/* Focus — window panel */}
+      <section aria-labelledby="focus-heading">
+        <div className={styles.window}>
+          <div className={styles.windowBar}>
+            <span className={styles.windowLabel} id="focus-heading">
+              FOCUS.log
+            </span>
+            <span className={styles.windowControls} aria-hidden="true">
+              [&minus;] [&square;] [&times;]
+            </span>
+          </div>
+          <div className={styles.windowBody}>
+            <ul className={styles.focusList}>
+              {profile.currentFocus.map((item) => (
+                <li key={item} className={styles.focusItem}>
+                  <span className={styles.focusBullet} aria-hidden="true">
+                    &gt;
+                  </span>
+                  {item}
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </section>
 
-        {upcoming.length > 0 && (
-          <div className={styles.speakingGroup}>
-            <h3 className={styles.speakingLabel}>Upcoming</h3>
-            <div className={styles.engagements}>
-              {upcoming.map((talk) => (
-                <article key={talk.title} className={styles.talkCard}>
-                  <p className={styles.talkTitle}>{talk.title}</p>
-                  <p className={styles.talkMeta}>
-                    {talk.event} &mdash; {talk.date}
-                  </p>
-                </article>
+      {/* Speaking — window panel */}
+      <section aria-labelledby="speaking-heading">
+        <div className={styles.window}>
+          <div className={styles.windowBar}>
+            <span className={styles.windowLabel} id="speaking-heading">
+              TALKS.json
+            </span>
+            <span className={styles.windowControls} aria-hidden="true">
+              [&minus;] [&square;] [&times;]
+            </span>
+          </div>
+          <div className={styles.windowBody}>
+            {upcoming.length > 0 && (
+              <div className={styles.talkGroup}>
+                <p className={styles.talkGroupLabel}>// upcoming</p>
+                {upcoming.map((talk) => (
+                  <article key={talk.title} className={styles.talkCard}>
+                    <p className={styles.talkTitle}>{talk.title}</p>
+                    <p className={styles.talkMeta}>
+                      {talk.event} &mdash; {talk.date}
+                    </p>
+                  </article>
+                ))}
+              </div>
+            )}
+            {past.length > 0 && (
+              <div className={styles.talkGroup}>
+                <p className={styles.talkGroupLabel}>// past</p>
+                {past.map((talk) => (
+                  <article key={talk.title} className={styles.talkCard}>
+                    <p className={styles.talkTitle}>{talk.title}</p>
+                    <p className={styles.talkMeta}>
+                      {talk.event} &mdash; {talk.date}
+                    </p>
+                  </article>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      </section>
+
+      {/* Connect — window panel */}
+      <section aria-labelledby="connect-heading">
+        <div className={styles.window}>
+          <div className={styles.windowBar}>
+            <span className={styles.windowLabel} id="connect-heading">
+              LINKS.sh
+            </span>
+            <span className={styles.windowControls} aria-hidden="true">
+              [&minus;] [&square;] [&times;]
+            </span>
+          </div>
+          <div className={styles.windowBody}>
+            <div className={styles.linkGrid}>
+              {profile.links.map((link) => (
+                <a
+                  key={link.href}
+                  href={link.href}
+                  className={styles.connectLink}
+                  target={link.external ? "_blank" : undefined}
+                  rel={link.external ? "noopener noreferrer" : undefined}
+                >
+                  {link.label}
+                  {link.external && (
+                    <span aria-hidden="true"> &rarr;</span>
+                  )}
+                </a>
               ))}
             </div>
           </div>
-        )}
-
-        {past.length > 0 && (
-          <div className={styles.speakingGroup}>
-            <h3 className={styles.speakingLabel}>Past</h3>
-            <div className={styles.engagements}>
-              {past.map((talk) => (
-                <article key={talk.title} className={styles.talkCard}>
-                  <p className={styles.talkTitle}>{talk.title}</p>
-                  <p className={styles.talkMeta}>
-                    {talk.event} &mdash; {talk.date}
-                  </p>
-                </article>
-              ))}
-            </div>
-          </div>
-        )}
-      </section>
-
-      <section className={styles.section} aria-labelledby="links-heading">
-        <h2 id="links-heading" className={styles.sectionTitle}>
-          // connect
-        </h2>
-        <div className={styles.linkGrid}>
-          {profile.links.map((link) => (
-            <a
-              key={link.href}
-              href={link.href}
-              className={styles.connectLink}
-              target={link.external ? "_blank" : undefined}
-              rel={link.external ? "noopener noreferrer" : undefined}
-            >
-              {link.label}
-              {link.external && (
-                <span className={styles.arrow} aria-hidden="true">
-                  {" "}
-                  &rarr;
-                </span>
-              )}
-            </a>
-          ))}
         </div>
       </section>
     </div>

--- a/content/profile.ts
+++ b/content/profile.ts
@@ -2,7 +2,7 @@ export interface Profile {
   name: string;
   title: string;
   tagline: string;
-  about: string[];
+  about: string;
   currentFocus: string[];
   links: ProfileLink[];
   speaking: SpeakingEngagement[];
@@ -25,16 +25,14 @@ export interface SpeakingEngagement {
 export const profile: Profile = {
   name: "Raj Navakoti",
   title: "Staff Software Engineer",
-  tagline: "Building at the intersection of AI, architecture, and human cognition.",
-  about: [
-    "I design and build software systems that scale. My work spans enterprise architecture, domain-driven design, and applied AI. I'm fascinated by how neuroscience principles can inform better software design.",
-    "Currently focused on demand-driven architecture methodologies and exploring how large language models can augment software engineering workflows.",
-  ],
+  tagline: "AI . Architecture . Cognition",
+  about:
+    "I design systems at the intersection of software architecture, AI, and how humans actually think. Currently deep into demand-driven design and LLM-augmented engineering.",
   currentFocus: [
-    "Demand-Driven Context framework for architecture knowledge",
-    "AI-augmented development workflows with Claude Code",
+    "Demand-Driven Context framework",
+    "AI-augmented dev workflows",
     "Enterprise DDD at scale",
-    "Neuroscience-inspired system design",
+    "Neuroscience x system design",
   ],
   links: [
     { label: "GitHub", href: "https://github.com/rajnavakoti", external: true },


### PR DESCRIPTION
## Summary
- Hero section restyled as terminal window with `$ whoami` prompt and blinking cursor
- All content sections wrapped in retro OS-style window panels with title bars (ABOUT.md, FOCUS.log, TALKS.json, LINKS.sh)
- Simplified profile data — shorter tagline, single about paragraph, concise focus items
- Talk cards invert on hover for bold interaction feedback

## Test plan
- [x] All 7 home page tests pass
- [x] All 53 tests across the project pass
- [x] Build succeeds with static export
- [ ] Verify responsive layout at 320px, 768px, 1024px, 1440px
- [ ] Verify dark and light mode both look correct

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)