### PR TITLE
feat: redesign header and footer as terminal toolbar and status bar

### DIFF
--- a/components/Footer.module.css
+++ b/components/Footer.module.css
@@ -1,51 +1,75 @@
 .footer {
+  background-color: var(--color-text);
+  color: var(--color-bg);
   border-top: var(--border-thick);
-  background-color: var(--color-bg);
 }
 
-.inner {
+.statusBar {
   display: flex;
   align-items: center;
   justify-content: space-between;
   max-width: var(--max-width);
   margin: 0 auto;
-  padding: var(--space-lg);
+  padding: var(--space-sm) var(--space-lg);
+}
+
+.left {
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+}
+
+.label {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-bold);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  opacity: 0.5;
 }
 
 .links {
   display: flex;
-  gap: var(--space-lg);
+  gap: var(--space-md);
 }
 
 .link {
   font-family: var(--font-mono);
-  font-size: var(--text-sm);
+  font-size: var(--text-xs);
   font-weight: var(--weight-bold);
   text-transform: uppercase;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.08em;
+  color: var(--color-bg);
   border-bottom: none;
   padding: var(--space-xs) var(--space-sm);
 }
 
 .link:hover {
-  background-color: var(--color-text);
-  color: var(--color-bg);
+  background-color: var(--color-bg);
+  color: var(--color-text);
 }
 
 .copyright {
   font-family: var(--font-mono);
   font-size: var(--text-xs);
-  color: var(--color-text-muted);
+  color: var(--color-bg);
+  opacity: 0.5;
 }
 
 @media (max-width: 768px) {
-  .inner {
+  .statusBar {
     flex-direction: column;
-    gap: var(--space-md);
+    gap: var(--space-sm);
     text-align: center;
+    padding: var(--space-md);
+  }
+
+  .left {
+    flex-direction: column;
+    gap: var(--space-sm);
   }
 
   .links {
-    gap: var(--space-md);
+    gap: var(--space-sm);
   }
 }

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -6,26 +6,29 @@ export function Footer() {
 
   return (
     <footer className={styles.footer}>
-      <div className={styles.inner}>
-        <div className={styles.links}>
-          {socialLinks.map((link) => (
-            <a
-              key={link.href}
-              href={link.href}
-              className={styles.link}
-              target={link.href.startsWith("mailto:") ? undefined : "_blank"}
-              rel={
-                link.href.startsWith("mailto:")
-                  ? undefined
-                  : "noopener noreferrer"
-              }
-            >
-              {link.label}
-            </a>
-          ))}
+      <div className={styles.statusBar}>
+        <div className={styles.left}>
+          <span className={styles.label}>LINKS:</span>
+          <div className={styles.links}>
+            {socialLinks.map((link) => (
+              <a
+                key={link.href}
+                href={link.href}
+                className={styles.link}
+                target={link.href.startsWith("mailto:") ? undefined : "_blank"}
+                rel={
+                  link.href.startsWith("mailto:")
+                    ? undefined
+                    : "noopener noreferrer"
+                }
+              >
+                {link.label}
+              </a>
+            ))}
+          </div>
         </div>
         <p className={styles.copyright}>
-          {currentYear} Raj Navakoti
+          &copy; {currentYear} raj_navakoti
         </p>
       </div>
     </footer>

--- a/components/Header.module.css
+++ b/components/Header.module.css
@@ -2,30 +2,38 @@
   position: sticky;
   top: 0;
   z-index: 50;
-  background-color: var(--color-bg);
+  background-color: var(--color-text);
+  color: var(--color-bg);
   border-bottom: var(--border-thick);
 }
 
-.nav {
+.toolbar {
   display: flex;
   align-items: center;
   justify-content: space-between;
   max-width: var(--max-width);
   margin: 0 auto;
-  padding: var(--space-md) var(--space-lg);
+  padding: var(--space-sm) var(--space-lg);
+}
+
+.toolbarLeft {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
 }
 
 .logo {
   font-family: var(--font-mono);
-  font-size: var(--text-xl);
+  font-size: var(--text-lg);
   font-weight: var(--weight-black);
   letter-spacing: -0.03em;
   text-transform: uppercase;
+  color: var(--color-bg);
   border-bottom: none;
 }
 
 .logo:hover {
-  background-color: transparent;
+  background-color: var(--color-bg);
   color: var(--color-text);
 }
 
@@ -33,10 +41,58 @@
   opacity: 0.4;
 }
 
-.controls {
+.separator {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--color-bg);
+  opacity: 0.3;
+}
+
+.status {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--color-bg);
+  opacity: 0.5;
+}
+
+.toolbarRight {
   display: flex;
   align-items: center;
-  gap: var(--space-sm);
+  gap: var(--space-md);
+}
+
+.links {
+  display: flex;
+  gap: 0;
+  list-style: none;
+}
+
+.link {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-bold);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  padding: var(--space-xs) var(--space-md);
+  color: var(--color-bg);
+  border-bottom: none;
+  border: 1px solid transparent;
+}
+
+.link:hover {
+  background-color: var(--color-bg);
+  color: var(--color-text);
+}
+
+.linkActive {
+  border: 1px solid var(--color-bg);
+  opacity: 1;
+}
+
+.activeMarker {
+  font-weight: var(--weight-bold);
 }
 
 .menuToggle {
@@ -46,44 +102,30 @@
   font-weight: var(--weight-bold);
   background: none;
   border: none;
-  color: var(--color-text);
+  color: var(--color-bg);
   padding: var(--space-xs) var(--space-sm);
   cursor: pointer;
 }
 
 .menuToggle:hover {
-  background-color: var(--color-text);
-  color: var(--color-bg);
-}
-
-.links {
-  display: flex;
-  gap: var(--space-xl);
-  list-style: none;
-}
-
-.link {
-  font-family: var(--font-mono);
-  font-size: var(--text-sm);
-  font-weight: var(--weight-bold);
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  padding: var(--space-xs) var(--space-sm);
-  border-bottom: none;
-}
-
-.link:hover {
-  background-color: var(--color-text);
-  color: var(--color-bg);
-}
-
-.linkActive {
-  background-color: var(--color-text);
-  color: var(--color-bg);
+  background-color: var(--color-bg);
+  color: var(--color-text);
 }
 
 /* Mobile */
 @media (max-width: 768px) {
+  .toolbar {
+    padding: var(--space-sm) var(--space-md);
+  }
+
+  .status {
+    display: none;
+  }
+
+  .separator {
+    display: none;
+  }
+
   .menuToggle {
     display: block;
   }
@@ -96,7 +138,7 @@
     right: 0;
     flex-direction: column;
     gap: 0;
-    background-color: var(--color-bg);
+    background-color: var(--color-text);
     border-bottom: var(--border-thick);
   }
 
@@ -107,7 +149,17 @@
   .link {
     display: block;
     padding: var(--space-md) var(--space-lg);
-    border-bottom: var(--border-muted);
-    font-size: var(--text-base);
+    border-bottom: 1px solid var(--color-bg);
+    border: none;
+    border-bottom: 1px solid var(--color-border-muted);
+    font-size: var(--text-sm);
+    opacity: 0.8;
+  }
+
+  .link:hover,
+  .linkActive {
+    opacity: 1;
+    background-color: var(--color-bg);
+    color: var(--color-text);
   }
 }

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -13,45 +13,57 @@ export function Header() {
 
   return (
     <header className={styles.header}>
-      <nav className={styles.nav} aria-label="Main navigation">
-        <Link href="/" className={styles.logo}>
-          RAJ<span className={styles.logoAccent}>_</span>N
-        </Link>
+      <div className={styles.toolbar}>
+        <div className={styles.toolbarLeft}>
+          <Link href="/" className={styles.logo}>
+            RAJ<span className={styles.logoAccent}>_</span>N
+          </Link>
+          <span className={styles.separator} aria-hidden="true">
+            |
+          </span>
+          <span className={styles.status}>sys.online</span>
+        </div>
 
-        <div className={styles.controls}>
+        <div className={styles.toolbarRight}>
+          <nav aria-label="Main navigation">
+            <ul
+              id="main-nav-links"
+              className={`${styles.links} ${menuOpen ? styles.linksOpen : ""}`}
+              role="list"
+            >
+              {navLinks.map((link) => (
+                <li key={link.href}>
+                  <Link
+                    href={link.href}
+                    className={`${styles.link} ${
+                      pathname === link.href ? styles.linkActive : ""
+                    }`}
+                    onClick={() => setMenuOpen(false)}
+                    aria-current={pathname === link.href ? "page" : undefined}
+                  >
+                    {pathname === link.href && (
+                      <span className={styles.activeMarker} aria-hidden="true">
+                        &gt;{" "}
+                      </span>
+                    )}
+                    {link.label}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </nav>
           <ThemeToggle />
           <button
             className={styles.menuToggle}
-          onClick={() => setMenuOpen(!menuOpen)}
-          aria-expanded={menuOpen}
-          aria-controls="main-nav-links"
-          aria-label={menuOpen ? "Close menu" : "Open menu"}
-        >
-          {menuOpen ? "[X]" : "[=]"}
+            onClick={() => setMenuOpen(!menuOpen)}
+            aria-expanded={menuOpen}
+            aria-controls="main-nav-links"
+            aria-label={menuOpen ? "Close menu" : "Open menu"}
+          >
+            {menuOpen ? "[X]" : "[=]"}
           </button>
         </div>
-
-        <ul
-          id="main-nav-links"
-          className={`${styles.links} ${menuOpen ? styles.linksOpen : ""}`}
-          role="list"
-        >
-          {navLinks.map((link) => (
-            <li key={link.href}>
-              <Link
-                href={link.href}
-                className={`${styles.link} ${
-                  pathname === link.href ? styles.linkActive : ""
-                }`}
-                onClick={() => setMenuOpen(false)}
-                aria-current={pathname === link.href ? "page" : undefined}
-              >
-                {link.label}
-              </Link>
-            </li>
-          ))}
-        </ul>
-      </nav>
+      </div>
     </header>
   );
 }

--- a/components/ThemeToggle.module.css
+++ b/components/ThemeToggle.module.css
@@ -1,21 +1,22 @@
 .toggle {
   font-family: var(--font-mono);
-  font-size: var(--text-sm);
+  font-size: var(--text-xs);
   font-weight: var(--weight-bold);
   background: none;
-  border: none;
-  color: var(--color-text);
+  border: 1px solid var(--color-bg);
+  color: var(--color-bg);
   padding: var(--space-xs) var(--space-sm);
   cursor: pointer;
   letter-spacing: 0.05em;
+  text-transform: uppercase;
 }
 
 .toggle:hover {
-  background-color: var(--color-text);
-  color: var(--color-bg);
+  background-color: var(--color-bg);
+  color: var(--color-text);
 }
 
 .toggle:focus-visible {
-  outline: 3px solid var(--color-text);
+  outline: 2px solid var(--color-bg);
   outline-offset: 2px;
 }


### PR DESCRIPTION
## Summary
- Header inverted (white-on-black) styled as OS toolbar with `RAJ_N` logo, `sys.online` status, and monospace nav
- Active nav link marked with `>` prefix and bordered highlight
- Footer restyled as terminal status bar with `LINKS:` label prefix
- ThemeToggle restyled with bordered button to match inverted header
- Mobile menu retained with updated styling

## Test plan
- [x] All 4 header tests pass
- [x] All 3 footer tests pass
- [x] All 52 tests across the project pass
- [x] Build succeeds with static export
- [ ] Verify responsive layout at 320px, 768px, 1024px
- [ ] Verify dark and light mode both look correct

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)