### PR TITLE
feat: redesign blog listing and post pages with windowed aesthetic

### DIFF
--- a/app/blog/[slug]/page.module.css
+++ b/app/blog/[slug]/page.module.css
@@ -4,16 +4,33 @@
   padding: var(--space-2xl) var(--space-lg);
 }
 
-.header {
-  padding-bottom: var(--space-xl);
-  border-bottom: var(--border-thick);
-  margin-bottom: var(--space-xl);
+/* === Window === */
+.window {
+  border: var(--border-medium);
+  overflow: hidden;
 }
 
-.meta {
+.windowBar {
   display: flex;
-  gap: var(--space-md);
-  margin-bottom: var(--space-md);
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-sm) var(--space-md);
+  background-color: var(--color-bg-secondary);
+  border-bottom: var(--border-medium);
+}
+
+.windowLabel {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-bold);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.windowMeta {
+  display: flex;
+  gap: var(--space-sm);
+  align-items: center;
 }
 
 .date {
@@ -22,10 +39,28 @@
   color: var(--color-text-muted);
 }
 
+.separator {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  opacity: 0.4;
+}
+
 .readingTime {
   font-family: var(--font-mono);
   font-size: var(--text-xs);
   color: var(--color-text-muted);
+}
+
+.windowBody {
+  padding: var(--space-xl) var(--space-lg);
+}
+
+/* === Header === */
+.header {
+  padding-bottom: var(--space-xl);
+  border-bottom: var(--border-muted);
+  margin-bottom: var(--space-xl);
 }
 
 .title {
@@ -129,9 +164,7 @@
 
 /* === Footer === */
 .footer {
-  margin-top: var(--space-2xl);
-  padding-top: var(--space-lg);
-  border-top: var(--border-thick);
+  margin-top: var(--space-xl);
 }
 
 .backLink {
@@ -142,7 +175,6 @@
   letter-spacing: 0.05em;
   padding: var(--space-sm) var(--space-md);
   border: var(--border-medium);
-  border-bottom: var(--border-medium);
 }
 
 .backLink:hover {
@@ -152,6 +184,10 @@
 
 @media (max-width: 768px) {
   .article {
+    padding: var(--space-lg) var(--space-md);
+  }
+
+  .windowBody {
     padding: var(--space-lg) var(--space-md);
   }
 

--- a/app/blog/[slug]/page.tsx
+++ b/app/blog/[slug]/page.tsx
@@ -68,26 +68,37 @@ export default async function BlogPostPage({ params }: PageProps) {
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
       />
-      <header className={styles.header}>
-        <div className={styles.meta}>
-          <time className={styles.date}>{post.frontmatter.date}</time>
-          <span className={styles.readingTime}>{post.readingTime}</span>
-        </div>
-        <h1 className={styles.title}>{post.frontmatter.title}</h1>
-        <div className={styles.tags}>
-          {post.frontmatter.tags.map((tag) => (
-            <span key={tag} className={styles.tag}>
-              {tag}
-            </span>
-          ))}
-        </div>
-      </header>
 
-      <div className={styles.content}>{content}</div>
+      <div className={styles.window}>
+        <div className={styles.windowBar}>
+          <span className={styles.windowLabel}>
+            {slug}.mdx
+          </span>
+          <div className={styles.windowMeta}>
+            <time className={styles.date}>{post.frontmatter.date}</time>
+            <span className={styles.separator} aria-hidden="true">|</span>
+            <span className={styles.readingTime}>{post.readingTime}</span>
+          </div>
+        </div>
+        <div className={styles.windowBody}>
+          <header className={styles.header}>
+            <h1 className={styles.title}>{post.frontmatter.title}</h1>
+            <div className={styles.tags}>
+              {post.frontmatter.tags.map((tag) => (
+                <span key={tag} className={styles.tag}>
+                  {tag}
+                </span>
+              ))}
+            </div>
+          </header>
+
+          <div className={styles.content}>{content}</div>
+        </div>
+      </div>
 
       <footer className={styles.footer}>
         <a href="/blog" className={styles.backLink}>
-          &larr; Back to blog
+          &larr; cd /blog
         </a>
       </footer>
     </article>

--- a/app/blog/page.module.css
+++ b/app/blog/page.module.css
@@ -4,27 +4,44 @@
   padding: var(--space-2xl) var(--space-lg);
 }
 
-.header {
-  padding-bottom: var(--space-2xl);
-  border-bottom: var(--border-thick);
-  margin-bottom: var(--space-2xl);
+.window {
+  border: var(--border-medium);
+  overflow: hidden;
 }
 
-.title {
+.windowBar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-sm) var(--space-md);
+  background-color: var(--color-bg-secondary);
+  border-bottom: var(--border-medium);
+}
+
+.windowLabel {
   font-family: var(--font-mono);
-  font-size: var(--text-2xl);
-  font-weight: var(--weight-black);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-bold);
   text-transform: uppercase;
-  margin-bottom: var(--space-sm);
+  letter-spacing: 0.1em;
 }
 
-.subtitle {
+.windowMeta {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
   color: var(--color-text-muted);
-  font-size: var(--text-base);
+}
+
+.windowBody {
+  padding: var(--space-lg);
 }
 
 @media (max-width: 768px) {
   .page {
     padding: var(--space-lg) var(--space-md);
+  }
+
+  .windowBody {
+    padding: var(--space-md);
   }
 }

--- a/app/blog/page.test.tsx
+++ b/app/blog/page.test.tsx
@@ -2,9 +2,9 @@ import { render, screen } from "@testing-library/react";
 import BlogPage from "./page";
 
 describe("BlogPage", () => {
-  it("renders the blog heading", () => {
+  it("renders the blog window panel", () => {
     render(<BlogPage />);
-    expect(screen.getByText("// blog")).toBeInTheDocument();
+    expect(screen.getByText("BLOG.md")).toBeInTheDocument();
   });
 
   it("renders blog posts", () => {

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -13,14 +13,17 @@ export default function BlogPage() {
 
   return (
     <div className={styles.page}>
-      <header className={styles.header}>
-        <h1 className={styles.title}>// blog</h1>
-        <p className={styles.subtitle}>
-          Writing about architecture, DDD, AI, and engineering.
-        </p>
-      </header>
-
-      <BlogList posts={posts} allTags={allTags} />
+      <div className={styles.window}>
+        <div className={styles.windowBar}>
+          <span className={styles.windowLabel}>BLOG.md</span>
+          <span className={styles.windowMeta}>
+            {posts.length} {posts.length === 1 ? "post" : "posts"}
+          </span>
+        </div>
+        <div className={styles.windowBody}>
+          <BlogList posts={posts} allTags={allTags} />
+        </div>
+      </div>
     </div>
   );
 }

--- a/components/BlogList.module.css
+++ b/components/BlogList.module.css
@@ -3,7 +3,19 @@
   display: flex;
   gap: var(--space-sm);
   flex-wrap: wrap;
+  align-items: center;
   margin-bottom: var(--space-xl);
+  padding-bottom: var(--space-md);
+  border-bottom: var(--border-muted);
+}
+
+.filterLabel {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  margin-right: var(--space-xs);
 }
 
 .tagButton {
@@ -53,21 +65,22 @@
   color: inherit;
 }
 
+/* === Post Card — mini window === */
 .postCard {
-  padding: var(--space-lg);
   border: var(--border-thin);
-  background-color: var(--color-surface);
+  overflow: hidden;
 }
 
 .postCard:hover {
-  background-color: var(--color-surface-hover);
   border-color: var(--color-text);
 }
 
-.postMeta {
+.postBar {
   display: flex;
-  gap: var(--space-md);
-  margin-bottom: var(--space-sm);
+  justify-content: space-between;
+  padding: var(--space-xs) var(--space-md);
+  background-color: var(--color-bg-secondary);
+  border-bottom: var(--border-thin);
 }
 
 .date {
@@ -82,12 +95,21 @@
   color: var(--color-text-muted);
 }
 
+.postBody {
+  padding: var(--space-md);
+}
+
 .postTitle {
   font-family: var(--font-mono);
   font-size: var(--text-lg);
   font-weight: var(--weight-bold);
   margin-bottom: var(--space-sm);
   line-height: var(--leading-tight);
+}
+
+.postCard:hover .postTitle {
+  text-decoration: underline;
+  text-underline-offset: 3px;
 }
 
 .excerpt {

--- a/components/BlogList.test.tsx
+++ b/components/BlogList.test.tsx
@@ -82,6 +82,6 @@ describe("BlogList", () => {
 
     await user.click(screen.getByRole("button", { name: "AI" }));
 
-    expect(screen.getByText("No posts with this tag.")).toBeInTheDocument();
+    expect(screen.getByText("// no posts matching this filter")).toBeInTheDocument();
   });
 });

--- a/components/BlogList.tsx
+++ b/components/BlogList.tsx
@@ -20,6 +20,9 @@ export function BlogList({ posts, allTags }: BlogListProps) {
   return (
     <>
       <div className={styles.tagFilter} role="group" aria-label="Filter by tag">
+        <span className={styles.filterLabel} aria-hidden="true">
+          filter:
+        </span>
         <button
           className={`${styles.tagButton} ${!activeTag ? styles.tagActive : ""}`}
           onClick={() => setActiveTag(null)}
@@ -40,14 +43,14 @@ export function BlogList({ posts, allTags }: BlogListProps) {
       </div>
 
       {filtered.length === 0 ? (
-        <p className={styles.empty}>No posts with this tag.</p>
+        <p className={styles.empty}>// no posts matching this filter</p>
       ) : (
         <ul className={styles.postList}>
           {filtered.map((post) => (
             <li key={post.slug}>
               <Link href={`/blog/${post.slug}`} className={styles.postLink}>
                 <article className={styles.postCard}>
-                  <div className={styles.postMeta}>
+                  <div className={styles.postBar}>
                     <time className={styles.date}>
                       {post.frontmatter.date}
                     </time>
@@ -55,18 +58,20 @@ export function BlogList({ posts, allTags }: BlogListProps) {
                       {post.readingTime}
                     </span>
                   </div>
-                  <h2 className={styles.postTitle}>
-                    {post.frontmatter.title}
-                  </h2>
-                  <p className={styles.excerpt}>
-                    {post.frontmatter.excerpt}
-                  </p>
-                  <div className={styles.tags}>
-                    {post.frontmatter.tags.map((tag) => (
-                      <span key={tag} className={styles.tag}>
-                        {tag}
-                      </span>
-                    ))}
+                  <div className={styles.postBody}>
+                    <h2 className={styles.postTitle}>
+                      {post.frontmatter.title}
+                    </h2>
+                    <p className={styles.excerpt}>
+                      {post.frontmatter.excerpt}
+                    </p>
+                    <div className={styles.tags}>
+                      {post.frontmatter.tags.map((tag) => (
+                        <span key={tag} className={styles.tag}>
+                          {tag}
+                        </span>
+                      ))}
+                    </div>
                   </div>
                 </article>
               </Link>


### PR DESCRIPTION
## Summary
- Blog listing wrapped in window panel with `BLOG.md` title bar and post count
- Post cards styled as mini-windows with date/reading-time title bar
- Tag filter with `filter:` label prefix
- Individual blog posts wrapped in window with `slug.mdx` title bar
- Back link styled as `← cd /blog`

## Test plan
- [x] All 3 blog page tests pass
- [x] All 6 BlogList component tests pass
- [x] All 52 tests pass
- [x] Build succeeds with static export
- [ ] Verify responsive layout at 320px, 768px, 1024px
- [ ] Verify dark and light mode

Closes #43

🤖 Generated with [Claude Code](https://claude.com/claude-code)