### PR TITLE
feat: redesign presentations listing with windowed aesthetic

### DIFF
--- a/app/presentations/page.module.css
+++ b/app/presentations/page.module.css
@@ -4,25 +4,40 @@
   padding: var(--space-2xl) var(--space-lg);
 }
 
-.header {
-  padding-bottom: var(--space-2xl);
-  border-bottom: var(--border-thick);
-  margin-bottom: var(--space-2xl);
+/* === Outer Window === */
+.window {
+  border: var(--border-medium);
+  overflow: hidden;
 }
 
-.title {
+.windowBar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-sm) var(--space-md);
+  background-color: var(--color-bg-secondary);
+  border-bottom: var(--border-medium);
+}
+
+.windowLabel {
   font-family: var(--font-mono);
-  font-size: var(--text-2xl);
-  font-weight: var(--weight-black);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-bold);
   text-transform: uppercase;
-  margin-bottom: var(--space-sm);
+  letter-spacing: 0.1em;
 }
 
-.subtitle {
+.windowMeta {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
   color: var(--color-text-muted);
-  font-size: var(--text-base);
 }
 
+.windowBody {
+  padding: var(--space-lg);
+}
+
+/* === List === */
 .empty {
   color: var(--color-text-muted);
   font-family: var(--font-mono);
@@ -46,22 +61,25 @@
   color: inherit;
 }
 
+/* === Presentation Card — mini window === */
 .card {
-  padding: var(--space-lg);
-  border: var(--border-medium);
-  background-color: var(--color-surface);
+  border: var(--border-thin);
+  overflow: hidden;
 }
 
 .card:hover {
-  background-color: var(--color-surface-hover);
   border-color: var(--color-text);
 }
 
-.meta {
+.cardBar {
   display: flex;
-  gap: var(--space-md);
-  margin-bottom: var(--space-md);
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--space-xs) var(--space-md);
+  background-color: var(--color-bg-secondary);
+  border-bottom: var(--border-thin);
   flex-wrap: wrap;
+  gap: var(--space-sm);
 }
 
 .event {
@@ -70,8 +88,12 @@
   font-weight: var(--weight-bold);
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  padding: 2px var(--space-sm);
-  border: var(--border-thin);
+}
+
+.cardMeta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
 }
 
 .date {
@@ -80,10 +102,21 @@
   color: var(--color-text-muted);
 }
 
+.separator {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  opacity: 0.4;
+}
+
 .slides {
   font-family: var(--font-mono);
   font-size: var(--text-xs);
   color: var(--color-text-muted);
+}
+
+.cardBody {
+  padding: var(--space-md);
 }
 
 .cardTitle {
@@ -92,6 +125,11 @@
   font-weight: var(--weight-bold);
   margin-bottom: var(--space-sm);
   line-height: var(--leading-tight);
+}
+
+.card:hover .cardTitle {
+  text-decoration: underline;
+  text-underline-offset: 3px;
 }
 
 .description {
@@ -103,6 +141,10 @@
 @media (max-width: 768px) {
   .page {
     padding: var(--space-lg) var(--space-md);
+  }
+
+  .windowBody {
+    padding: var(--space-md);
   }
 
   .cardTitle {

--- a/app/presentations/page.test.tsx
+++ b/app/presentations/page.test.tsx
@@ -14,9 +14,9 @@ jest.mock("next/link", () => {
 });
 
 describe("PresentationsPage", () => {
-  it("renders the presentations heading", () => {
+  it("renders the presentations window panel", () => {
     render(<PresentationsPage />);
-    expect(screen.getByText("// presentations")).toBeInTheDocument();
+    expect(screen.getByText("TALKS/")).toBeInTheDocument();
   });
 
   it("renders presentation cards", () => {

--- a/app/presentations/page.tsx
+++ b/app/presentations/page.tsx
@@ -12,39 +12,47 @@ export default function PresentationsPage() {
 
   return (
     <div className={styles.page}>
-      <header className={styles.header}>
-        <h1 className={styles.title}>// presentations</h1>
-        <p className={styles.subtitle}>
-          Conference talks and presentations.
-        </p>
-      </header>
-
-      {presentations.length === 0 ? (
-        <p className={styles.empty}>No presentations yet.</p>
-      ) : (
-        <ul className={styles.list}>
-          {presentations.map((pres) => (
-            <li key={pres.slug}>
-              <Link
-                href={`/presentations/${pres.slug}`}
-                className={styles.cardLink}
-              >
-                <article className={styles.card}>
-                  <div className={styles.meta}>
-                    <span className={styles.event}>{pres.event}</span>
-                    <time className={styles.date}>{pres.date}</time>
-                    <span className={styles.slides}>
-                      {pres.slideCount} slides
-                    </span>
-                  </div>
-                  <h2 className={styles.cardTitle}>{pres.title}</h2>
-                  <p className={styles.description}>{pres.description}</p>
-                </article>
-              </Link>
-            </li>
-          ))}
-        </ul>
-      )}
+      <div className={styles.window}>
+        <div className={styles.windowBar}>
+          <span className={styles.windowLabel}>TALKS/</span>
+          <span className={styles.windowMeta}>
+            {presentations.length} {presentations.length === 1 ? "talk" : "talks"}
+          </span>
+        </div>
+        <div className={styles.windowBody}>
+          {presentations.length === 0 ? (
+            <p className={styles.empty}>// no presentations yet</p>
+          ) : (
+            <ul className={styles.list}>
+              {presentations.map((pres) => (
+                <li key={pres.slug}>
+                  <Link
+                    href={`/presentations/${pres.slug}`}
+                    className={styles.cardLink}
+                  >
+                    <article className={styles.card}>
+                      <div className={styles.cardBar}>
+                        <span className={styles.event}>{pres.event}</span>
+                        <div className={styles.cardMeta}>
+                          <time className={styles.date}>{pres.date}</time>
+                          <span className={styles.separator} aria-hidden="true">|</span>
+                          <span className={styles.slides}>
+                            {pres.slideCount} slides
+                          </span>
+                        </div>
+                      </div>
+                      <div className={styles.cardBody}>
+                        <h2 className={styles.cardTitle}>{pres.title}</h2>
+                        <p className={styles.description}>{pres.description}</p>
+                      </div>
+                    </article>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Presentations listing wrapped in window panel with `TALKS/` title bar and talk count
- Presentation cards styled as mini-windows with event/date/slides title bar
- Title underlines on hover for clear interaction feedback

## Test plan
- [x] All 4 presentations page tests pass
- [x] All 52 tests pass
- [x] Build succeeds with static export
- [ ] Verify responsive layout at 320px, 768px, 1024px
- [ ] Verify dark and light mode

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)