### PR TITLE
feat: visual polish — CRT scanlines, offset shadows, typing animation

### DIFF
--- a/app/blog/[slug]/page.module.css
+++ b/app/blog/[slug]/page.module.css
@@ -7,6 +7,7 @@
 /* === Window === */
 .window {
   border: var(--border-medium);
+  box-shadow: var(--shadow-brutal-sm);
   overflow: hidden;
 }
 
@@ -15,7 +16,8 @@
   align-items: center;
   justify-content: space-between;
   padding: var(--space-sm) var(--space-md);
-  background-color: var(--color-bg-secondary);
+  background-color: var(--color-text);
+  color: var(--color-bg);
   border-bottom: var(--border-medium);
 }
 
@@ -175,11 +177,15 @@
   letter-spacing: 0.05em;
   padding: var(--space-sm) var(--space-md);
   border: var(--border-medium);
+  box-shadow: var(--shadow-brutal-sm);
+  display: inline-block;
 }
 
 .backLink:hover {
   background-color: var(--color-text);
   color: var(--color-bg);
+  transform: translate(-2px, -2px);
+  box-shadow: 6px 6px 0 var(--color-text);
 }
 
 @media (max-width: 768px) {

--- a/app/blog/page.module.css
+++ b/app/blog/page.module.css
@@ -6,6 +6,7 @@
 
 .window {
   border: var(--border-medium);
+  box-shadow: var(--shadow-brutal-sm);
   overflow: hidden;
 }
 
@@ -14,7 +15,8 @@
   align-items: center;
   justify-content: space-between;
   padding: var(--space-sm) var(--space-md);
-  background-color: var(--color-bg-secondary);
+  background-color: var(--color-text);
+  color: var(--color-bg);
   border-bottom: var(--border-medium);
 }
 
@@ -29,7 +31,7 @@
 .windowMeta {
   font-family: var(--font-mono);
   font-size: var(--text-xs);
-  color: var(--color-text-muted);
+  opacity: 0.5;
 }
 
 .windowBody {
@@ -39,6 +41,10 @@
 @media (max-width: 768px) {
   .page {
     padding: var(--space-lg) var(--space-md);
+  }
+
+  .window {
+    box-shadow: 3px 3px 0 var(--color-text);
   }
 
   .windowBody {

--- a/app/globals.css
+++ b/app/globals.css
@@ -28,6 +28,25 @@ body {
   overflow-x: hidden;
 }
 
+/* === CRT Scanline Overlay === */
+body::after {
+  content: "";
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: 9999;
+  background: repeating-linear-gradient(
+    0deg,
+    var(--color-scanline) 0px,
+    var(--color-scanline) 1px,
+    transparent 1px,
+    transparent 3px
+  );
+}
+
 /* === Typography === */
 h1,
 h2,
@@ -189,4 +208,15 @@ img {
   clip: rect(0, 0, 0, 0);
   white-space: nowrap;
   border: 0;
+}
+
+/* === ASCII Divider utility (used in pages) === */
+.ascii-divider {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  text-align: center;
+  letter-spacing: 0.3em;
+  padding: var(--space-sm) 0;
+  user-select: none;
 }

--- a/app/page.module.css
+++ b/app/page.module.css
@@ -8,25 +8,45 @@
 }
 
 /* ============================================
-   HERO — Terminal Window
+   ASCII DIVIDERS
+   ============================================ */
+.divider {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--color-border-muted);
+  text-align: center;
+  letter-spacing: 0.2em;
+  user-select: none;
+  overflow: hidden;
+}
+
+/* ============================================
+   HERO — Terminal Window (the star)
    ============================================ */
 .hero {
-  padding-top: var(--space-2xl);
+  padding-top: var(--space-xl);
 }
 
 .terminal {
   border: var(--border-thick);
+  box-shadow: var(--shadow-brutal);
   overflow: hidden;
+  position: relative;
 }
 
 .terminalBar {
   display: flex;
   align-items: center;
-  gap: var(--space-sm);
+  justify-content: space-between;
   padding: var(--space-sm) var(--space-md);
   background-color: var(--color-text);
   color: var(--color-bg);
   border-bottom: var(--border-thick);
+}
+
+.terminalDots {
+  display: flex;
+  gap: 6px;
 }
 
 .terminalDot {
@@ -40,35 +60,58 @@
   font-family: var(--font-mono);
   font-size: var(--text-xs);
   font-weight: var(--weight-bold);
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
-  margin-left: var(--space-sm);
+  letter-spacing: 0.05em;
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+}
+
+.terminalPid {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  opacity: 0.4;
 }
 
 .terminalBody {
-  padding: var(--space-xl) var(--space-lg);
+  padding: var(--space-2xl) var(--space-xl);
   background-color: var(--color-bg);
+  min-height: 280px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
 }
 
-.prompt {
+.promptLine {
   font-family: var(--font-mono);
   font-size: var(--text-sm);
   color: var(--color-text-muted);
-  margin-bottom: var(--space-lg);
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-sm);
 }
 
 .promptSymbol {
   color: var(--color-text);
-  font-weight: var(--weight-bold);
+  font-weight: var(--weight-black);
+}
+
+.promptText {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+}
+
+.output {
+  padding: var(--space-lg) 0 var(--space-xl);
 }
 
 .name {
-  font-size: var(--text-3xl);
+  font-size: var(--text-4xl);
   font-weight: var(--weight-black);
   text-transform: uppercase;
-  letter-spacing: -0.03em;
-  line-height: 1;
-  margin-bottom: var(--space-xs);
+  letter-spacing: -0.04em;
+  line-height: 0.9;
+  margin-bottom: var(--space-sm);
 }
 
 .title {
@@ -76,7 +119,20 @@
   font-size: var(--text-lg);
   font-weight: var(--weight-bold);
   color: var(--color-text-secondary);
-  margin-bottom: var(--space-md);
+  margin-bottom: var(--space-lg);
+}
+
+.taglineWrap {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+}
+
+.taglineBracket {
+  font-family: var(--font-mono);
+  font-size: var(--text-xl);
+  font-weight: var(--weight-black);
+  color: var(--color-text-muted);
 }
 
 .tagline {
@@ -87,32 +143,26 @@
   text-transform: uppercase;
 }
 
-.cursor {
+.blink {
+  animation: blink 0.8s step-end infinite;
   font-family: var(--font-mono);
   font-size: var(--text-sm);
-  margin-top: var(--space-xl);
-}
-
-.blink {
-  animation: blink 1s step-end infinite;
+  font-weight: var(--weight-bold);
 }
 
 @keyframes blink {
-  0%,
-  100% {
-    opacity: 1;
-  }
-  50% {
-    opacity: 0;
-  }
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0; }
 }
 
 /* ============================================
-   WINDOW PANELS — Retro OS style
+   WINDOW PANELS — with offset shadow
    ============================================ */
 .window {
   border: var(--border-medium);
+  box-shadow: var(--shadow-brutal-sm);
   overflow: hidden;
+  position: relative;
 }
 
 .windowBar {
@@ -120,7 +170,8 @@
   align-items: center;
   justify-content: space-between;
   padding: var(--space-sm) var(--space-md);
-  background-color: var(--color-bg-secondary);
+  background-color: var(--color-text);
+  color: var(--color-bg);
   border-bottom: var(--border-medium);
 }
 
@@ -135,7 +186,7 @@
 .windowControls {
   font-family: var(--font-mono);
   font-size: var(--text-xs);
-  color: var(--color-text-muted);
+  opacity: 0.5;
   letter-spacing: 0.05em;
 }
 
@@ -160,7 +211,7 @@
   list-style: none;
   display: flex;
   flex-direction: column;
-  gap: var(--space-sm);
+  gap: var(--space-md);
 }
 
 .focusItem {
@@ -169,6 +220,19 @@
   display: flex;
   align-items: baseline;
   gap: var(--space-sm);
+  padding: var(--space-sm) 0;
+  border-bottom: var(--border-muted);
+}
+
+.focusItem:last-child {
+  border-bottom: none;
+}
+
+.focusIndex {
+  font-size: var(--text-xs);
+  color: var(--color-border-muted);
+  font-weight: var(--weight-bold);
+  min-width: 2ch;
 }
 
 .focusBullet {
@@ -181,7 +245,7 @@
    SPEAKING
    ============================================ */
 .talkGroup {
-  margin-bottom: var(--space-lg);
+  margin-bottom: var(--space-xl);
 }
 
 .talkGroup:last-child {
@@ -193,13 +257,14 @@
   font-size: var(--text-xs);
   color: var(--color-text-muted);
   text-transform: uppercase;
-  letter-spacing: 0.1em;
+  letter-spacing: 0.15em;
   margin-bottom: var(--space-md);
+  font-weight: var(--weight-bold);
 }
 
 .talkCard {
   padding: var(--space-md);
-  border: var(--border-thin);
+  border: var(--border-medium);
   margin-bottom: var(--space-sm);
 }
 
@@ -210,6 +275,8 @@
 .talkCard:hover {
   background-color: var(--color-text);
   color: var(--color-bg);
+  box-shadow: var(--shadow-brutal-sm);
+  transform: translate(-2px, -2px);
 }
 
 .talkCard:hover .talkMeta {
@@ -217,11 +284,33 @@
   opacity: 0.7;
 }
 
+.talkCard:hover .talkBadge {
+  background-color: var(--color-bg);
+  color: var(--color-text);
+}
+
+.talkHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: var(--space-md);
+}
+
 .talkTitle {
   font-family: var(--font-mono);
   font-size: var(--text-sm);
   font-weight: var(--weight-bold);
   margin-bottom: var(--space-xs);
+}
+
+.talkBadge {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-black);
+  padding: 2px var(--space-sm);
+  border: var(--border-thin);
+  flex-shrink: 0;
+  letter-spacing: 0.1em;
 }
 
 .talkMeta {
@@ -248,11 +337,15 @@
   padding: var(--space-sm) var(--space-lg);
   border: var(--border-medium);
   background-color: var(--color-bg);
+  box-shadow: var(--shadow-brutal-sm);
+  position: relative;
 }
 
 .connectLink:hover {
   background-color: var(--color-text);
   color: var(--color-bg);
+  transform: translate(-2px, -2px);
+  box-shadow: 6px 6px 0 var(--color-text);
 }
 
 /* ============================================
@@ -265,11 +358,20 @@
   }
 
   .hero {
-    padding-top: var(--space-lg);
+    padding-top: var(--space-md);
+  }
+
+  .terminal {
+    box-shadow: 4px 4px 0 var(--color-text);
   }
 
   .terminalBody {
-    padding: var(--space-lg) var(--space-md);
+    padding: var(--space-xl) var(--space-md);
+    min-height: auto;
+  }
+
+  .terminalTitle {
+    display: none;
   }
 
   .name {
@@ -282,10 +384,19 @@
 
   .tagline {
     font-size: var(--text-sm);
+    letter-spacing: 0.1em;
+  }
+
+  .taglineBracket {
+    font-size: var(--text-base);
   }
 
   .windowBody {
     padding: var(--space-md);
+  }
+
+  .window {
+    box-shadow: 3px 3px 0 var(--color-text);
   }
 
   .linkGrid {
@@ -294,5 +405,19 @@
 
   .connectLink {
     text-align: center;
+    box-shadow: 3px 3px 0 var(--color-text);
+  }
+
+  .talkCard:hover {
+    transform: none;
+  }
+
+  .connectLink:hover {
+    transform: none;
+    box-shadow: 3px 3px 0 var(--color-text);
+  }
+
+  .divider {
+    font-size: 0.6rem;
   }
 }

--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -8,10 +8,9 @@ describe("Home", () => {
     expect(screen.getByText("Staff Software Engineer")).toBeInTheDocument();
   });
 
-  it("renders terminal prompt elements", () => {
+  it("renders terminal bar with path", () => {
     render(<Home />);
-    expect(screen.getByText(/whoami/)).toBeInTheDocument();
-    expect(screen.getByText("~/raj")).toBeInTheDocument();
+    expect(screen.getByText("raj@mono-space:~")).toBeInTheDocument();
   });
 
   it("renders about window panel", () => {
@@ -20,7 +19,7 @@ describe("Home", () => {
     expect(screen.getByText(/intersection of software/)).toBeInTheDocument();
   });
 
-  it("renders focus window with items", () => {
+  it("renders focus window with indexed items", () => {
     render(<Home />);
     expect(screen.getByText("FOCUS.log")).toBeInTheDocument();
     expect(
@@ -31,8 +30,13 @@ describe("Home", () => {
   it("renders speaking window with talks", () => {
     render(<Home />);
     expect(screen.getByText("TALKS.json")).toBeInTheDocument();
-    expect(screen.getByText("// upcoming")).toBeInTheDocument();
-    expect(screen.getByText("// past")).toBeInTheDocument();
+    expect(screen.getByText(/upcoming/)).toBeInTheDocument();
+    expect(screen.getByText(/past/)).toBeInTheDocument();
+  });
+
+  it("renders NEXT badge on upcoming talks", () => {
+    render(<Home />);
+    expect(screen.getByText("NEXT")).toBeInTheDocument();
   });
 
   it("renders connect window with links", () => {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,4 +1,5 @@
 import { profile } from "@/content/profile";
+import { TypingEffect } from "@/components/TypingEffect";
 import styles from "./page.module.css";
 
 export default function Home() {
@@ -11,28 +12,52 @@ export default function Home() {
       <section className={styles.hero}>
         <div className={styles.terminal}>
           <div className={styles.terminalBar}>
-            <span className={styles.terminalDot} aria-hidden="true" />
-            <span className={styles.terminalDot} aria-hidden="true" />
-            <span className={styles.terminalDot} aria-hidden="true" />
-            <span className={styles.terminalTitle}>~/raj</span>
+            <div className={styles.terminalDots} aria-hidden="true">
+              <span className={styles.terminalDot} />
+              <span className={styles.terminalDot} />
+              <span className={styles.terminalDot} />
+            </div>
+            <span className={styles.terminalTitle}>raj@mono-space:~</span>
+            <span className={styles.terminalPid} aria-hidden="true">
+              PID 1337
+            </span>
           </div>
           <div className={styles.terminalBody}>
-            <p className={styles.prompt}>
+            <div className={styles.promptLine}>
               <span className={styles.promptSymbol} aria-hidden="true">
                 $
-              </span>{" "}
-              whoami
-            </p>
-            <h1 className={styles.name}>{profile.name}</h1>
-            <p className={styles.title}>{profile.title}</p>
-            <p className={styles.tagline}>{profile.tagline}</p>
-            <p className={styles.cursor} aria-hidden="true">
-              <span className={styles.promptSymbol}>$</span>{" "}
-              <span className={styles.blink}>_</span>
-            </p>
+              </span>
+              <TypingEffect text=" whoami" className={styles.promptText} />
+            </div>
+            <div className={styles.output}>
+              <h1 className={styles.name}>{profile.name}</h1>
+              <p className={styles.title}>{profile.title}</p>
+              <div className={styles.taglineWrap}>
+                <span className={styles.taglineBracket} aria-hidden="true">
+                  [
+                </span>
+                <p className={styles.tagline}>{profile.tagline}</p>
+                <span className={styles.taglineBracket} aria-hidden="true">
+                  ]
+                </span>
+              </div>
+            </div>
+            <div className={styles.promptLine}>
+              <span className={styles.promptSymbol} aria-hidden="true">
+                $
+              </span>
+              <span className={styles.blink} aria-hidden="true">
+                _
+              </span>
+            </div>
           </div>
         </div>
       </section>
+
+      {/* ASCII divider */}
+      <div className={styles.divider} aria-hidden="true">
+        ========================================
+      </div>
 
       {/* About — window panel */}
       <section aria-labelledby="about-heading">
@@ -64,10 +89,13 @@ export default function Home() {
           </div>
           <div className={styles.windowBody}>
             <ul className={styles.focusList}>
-              {profile.currentFocus.map((item) => (
+              {profile.currentFocus.map((item, i) => (
                 <li key={item} className={styles.focusItem}>
+                  <span className={styles.focusIndex} aria-hidden="true">
+                    {String(i).padStart(2, "0")}
+                  </span>
                   <span className={styles.focusBullet} aria-hidden="true">
-                    &gt;
+                    //
                   </span>
                   {item}
                 </li>
@@ -91,10 +119,15 @@ export default function Home() {
           <div className={styles.windowBody}>
             {upcoming.length > 0 && (
               <div className={styles.talkGroup}>
-                <p className={styles.talkGroupLabel}>// upcoming</p>
+                <p className={styles.talkGroupLabel}>
+                  <span aria-hidden="true">&#9654; </span>upcoming
+                </p>
                 {upcoming.map((talk) => (
                   <article key={talk.title} className={styles.talkCard}>
-                    <p className={styles.talkTitle}>{talk.title}</p>
+                    <div className={styles.talkHeader}>
+                      <p className={styles.talkTitle}>{talk.title}</p>
+                      <span className={styles.talkBadge}>NEXT</span>
+                    </div>
                     <p className={styles.talkMeta}>
                       {talk.event} &mdash; {talk.date}
                     </p>
@@ -104,7 +137,9 @@ export default function Home() {
             )}
             {past.length > 0 && (
               <div className={styles.talkGroup}>
-                <p className={styles.talkGroupLabel}>// past</p>
+                <p className={styles.talkGroupLabel}>
+                  <span aria-hidden="true">&#9632; </span>past
+                </p>
                 {past.map((talk) => (
                   <article key={talk.title} className={styles.talkCard}>
                     <p className={styles.talkTitle}>{talk.title}</p>
@@ -150,6 +185,11 @@ export default function Home() {
           </div>
         </div>
       </section>
+
+      {/* Footer divider */}
+      <div className={styles.divider} aria-hidden="true">
+        ========================================
+      </div>
     </div>
   );
 }

--- a/app/presentations/page.module.css
+++ b/app/presentations/page.module.css
@@ -7,6 +7,7 @@
 /* === Outer Window === */
 .window {
   border: var(--border-medium);
+  box-shadow: var(--shadow-brutal-sm);
   overflow: hidden;
 }
 
@@ -15,7 +16,8 @@
   align-items: center;
   justify-content: space-between;
   padding: var(--space-sm) var(--space-md);
-  background-color: var(--color-bg-secondary);
+  background-color: var(--color-text);
+  color: var(--color-bg);
   border-bottom: var(--border-medium);
 }
 
@@ -30,7 +32,7 @@
 .windowMeta {
   font-family: var(--font-mono);
   font-size: var(--text-xs);
-  color: var(--color-text-muted);
+  opacity: 0.5;
 }
 
 .windowBody {
@@ -61,14 +63,16 @@
   color: inherit;
 }
 
-/* === Presentation Card — mini window === */
+/* === Presentation Card === */
 .card {
-  border: var(--border-thin);
+  border: var(--border-medium);
   overflow: hidden;
 }
 
 .card:hover {
   border-color: var(--color-text);
+  box-shadow: var(--shadow-brutal-sm);
+  transform: translate(-2px, -2px);
 }
 
 .cardBar {
@@ -77,7 +81,7 @@
   align-items: center;
   padding: var(--space-xs) var(--space-md);
   background-color: var(--color-bg-secondary);
-  border-bottom: var(--border-thin);
+  border-bottom: var(--border-medium);
   flex-wrap: wrap;
   gap: var(--space-sm);
 }
@@ -143,11 +147,20 @@
     padding: var(--space-lg) var(--space-md);
   }
 
+  .window {
+    box-shadow: 3px 3px 0 var(--color-text);
+  }
+
   .windowBody {
     padding: var(--space-md);
   }
 
   .cardTitle {
     font-size: var(--text-base);
+  }
+
+  .card:hover {
+    transform: none;
+    box-shadow: none;
   }
 }

--- a/components/BlogList.module.css
+++ b/components/BlogList.module.css
@@ -67,12 +67,14 @@
 
 /* === Post Card — mini window === */
 .postCard {
-  border: var(--border-thin);
+  border: var(--border-medium);
   overflow: hidden;
 }
 
 .postCard:hover {
   border-color: var(--color-text);
+  box-shadow: var(--shadow-brutal-sm);
+  transform: translate(-2px, -2px);
 }
 
 .postBar {
@@ -80,7 +82,7 @@
   justify-content: space-between;
   padding: var(--space-xs) var(--space-md);
   background-color: var(--color-bg-secondary);
-  border-bottom: var(--border-thin);
+  border-bottom: var(--border-medium);
 }
 
 .date {
@@ -139,5 +141,10 @@
 @media (max-width: 768px) {
   .postTitle {
     font-size: var(--text-base);
+  }
+
+  .postCard:hover {
+    transform: none;
+    box-shadow: none;
   }
 }

--- a/components/TypingEffect.module.css
+++ b/components/TypingEffect.module.css
@@ -1,0 +1,9 @@
+.typingCursor {
+  animation: cursorBlink 0.6s step-end infinite;
+  font-weight: var(--weight-bold);
+}
+
+@keyframes cursorBlink {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0; }
+}

--- a/components/TypingEffect.test.tsx
+++ b/components/TypingEffect.test.tsx
@@ -1,0 +1,16 @@
+import { render, screen } from "@testing-library/react";
+import { TypingEffect } from "./TypingEffect";
+
+describe("TypingEffect", () => {
+  it("renders with a cursor initially", () => {
+    render(<TypingEffect text="hello" delay={0} />);
+    expect(screen.getByText("_")).toBeInTheDocument();
+  });
+
+  it("accepts a custom className", () => {
+    const { container } = render(
+      <TypingEffect text="test" className="custom" />
+    );
+    expect(container.querySelector(".custom")).toBeInTheDocument();
+  });
+});

--- a/components/TypingEffect.tsx
+++ b/components/TypingEffect.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import styles from "./TypingEffect.module.css";
+
+interface TypingEffectProps {
+  text: string;
+  className?: string;
+  delay?: number;
+}
+
+export function TypingEffect({ text, className, delay = 0 }: TypingEffectProps) {
+  const [displayed, setDisplayed] = useState("");
+  const [started, setStarted] = useState(false);
+
+  useEffect(() => {
+    const startTimer = setTimeout(() => setStarted(true), delay);
+    return () => clearTimeout(startTimer);
+  }, [delay]);
+
+  useEffect(() => {
+    if (!started) return;
+    if (displayed.length >= text.length) return;
+
+    const timer = setTimeout(() => {
+      setDisplayed(text.slice(0, displayed.length + 1));
+    }, 50 + Math.random() * 30);
+
+    return () => clearTimeout(timer);
+  }, [displayed, text, started]);
+
+  return (
+    <span className={className}>
+      {displayed}
+      {displayed.length < text.length && (
+        <span className={styles.typingCursor} aria-hidden="true">
+          _
+        </span>
+      )}
+    </span>
+  );
+}

--- a/styles/variables.css
+++ b/styles/variables.css
@@ -3,17 +3,21 @@
 :root {
   /* === Colors (dark mode default) === */
   --color-bg: #000;
-  --color-bg-secondary: #111;
-  --color-bg-tertiary: #222;
-  --color-surface: #111;
-  --color-surface-hover: #222;
+  --color-bg-secondary: #0a0a0a;
+  --color-bg-tertiary: #151515;
+  --color-surface: #0a0a0a;
+  --color-surface-hover: #151515;
   --color-text: #fff;
   --color-text-secondary: #ccc;
-  --color-text-muted: #999;
+  --color-text-muted: #666;
   --color-border: #fff;
   --color-border-muted: #333;
   --color-accent: #fff;
   --color-accent-text: #000;
+
+  /* === Glow (for dark mode CRT feel) === */
+  --color-glow: rgba(255, 255, 255, 0.03);
+  --color-scanline: rgba(255, 255, 255, 0.015);
 
   /* === Typography === */
   --font-mono: var(--font-jetbrains-mono), "JetBrains Mono", monospace;
@@ -26,6 +30,7 @@
   --text-xl: 1.5rem;     /* 24px */
   --text-2xl: 2rem;      /* 32px */
   --text-3xl: 3rem;      /* 48px */
+  --text-4xl: 4rem;      /* 64px */
 
   --leading-tight: 1.1;
   --leading-normal: 1.5;
@@ -52,6 +57,11 @@
   --border-thick: 3px solid var(--color-border);
   --border-muted: 1px solid var(--color-border-muted);
 
+  /* === Offset Shadow (neo-brutalist) === */
+  --shadow-offset: 6px;
+  --shadow-brutal: var(--shadow-offset) var(--shadow-offset) 0 var(--color-text);
+  --shadow-brutal-sm: 4px 4px 0 var(--color-text);
+
   /* === Layout === */
   --max-width: 1200px;
   --max-width-narrow: 800px;
@@ -72,4 +82,10 @@
   --color-border-muted: #ccc;
   --color-accent: #000;
   --color-accent-text: #fff;
+
+  --color-glow: rgba(0, 0, 0, 0.02);
+  --color-scanline: rgba(0, 0, 0, 0.02);
+
+  --shadow-brutal: var(--shadow-offset) var(--shadow-offset) 0 var(--color-text);
+  --shadow-brutal-sm: 4px 4px 0 var(--color-text);
 }


### PR DESCRIPTION
## Summary
- CRT scanline overlay across entire page for retro monitor texture
- Neo-brutalist offset shadows on all window panels, cards, and buttons
- Cards lift + shift on hover with growing shadow for satisfying interaction
- `TypingEffect` component: character-by-character typing animation on hero `$ whoami`
- Hero terminal enlarged: 4xl name, `raj@mono-space:~` path, PID badge
- Focus items now indexed (`00 // item`)
- Upcoming talks get `NEXT` badge
- ASCII `========` dividers between sections
- Window title bars inverted (white-on-black) across all pages for consistency
- Connect buttons have brutalist offset shadows that grow on hover

## Test plan
- [x] All 56 tests pass (including new TypingEffect tests)
- [x] Build succeeds with static export
- [ ] Verify CRT scanlines visible but subtle in both dark and light mode
- [ ] Verify offset shadows look correct in both modes
- [ ] Verify typing animation plays on page load
- [ ] Verify hover interactions on cards and buttons

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)