### PR TITLE
feat: polish 404 page, presentation viewer, animations, and code blocks

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -220,3 +220,26 @@ img {
   padding: var(--space-sm) 0;
   user-select: none;
 }
+
+/* === Staggered Fade-In Animation === */
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.fade-in {
+  animation: fadeInUp 0.4s ease-out both;
+}
+
+.fade-in-1 { animation-delay: 0.05s; }
+.fade-in-2 { animation-delay: 0.1s; }
+.fade-in-3 { animation-delay: 0.15s; }
+.fade-in-4 { animation-delay: 0.2s; }
+.fade-in-5 { animation-delay: 0.25s; }
+.fade-in-6 { animation-delay: 0.3s; }

--- a/app/not-found.module.css
+++ b/app/not-found.module.css
@@ -1,0 +1,144 @@
+.page {
+  max-width: var(--max-width-narrow);
+  margin: 0 auto;
+  padding: var(--space-4xl) var(--space-lg);
+  min-height: 60vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.terminal {
+  border: var(--border-thick);
+  box-shadow: var(--shadow-brutal);
+  overflow: hidden;
+  width: 100%;
+}
+
+.terminalBar {
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+  padding: var(--space-sm) var(--space-md);
+  background-color: var(--color-text);
+  color: var(--color-bg);
+  border-bottom: var(--border-thick);
+}
+
+.terminalDots {
+  display: flex;
+  gap: 6px;
+}
+
+.terminalDot {
+  width: 12px;
+  height: 12px;
+  border: 2px solid var(--color-bg);
+  display: inline-block;
+}
+
+.terminalTitle {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-bold);
+  letter-spacing: 0.05em;
+}
+
+.terminalBody {
+  padding: var(--space-xl);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.line {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+}
+
+.prompt {
+  color: var(--color-text);
+  font-weight: var(--weight-black);
+}
+
+.error {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--color-text);
+  font-weight: var(--weight-bold);
+}
+
+.errorCode {
+  font-family: var(--font-mono);
+  font-size: var(--text-4xl);
+  font-weight: var(--weight-black);
+  line-height: 1;
+  letter-spacing: -0.04em;
+  padding: var(--space-md) 0;
+}
+
+.message {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  line-height: var(--leading-relaxed);
+}
+
+.actions {
+  margin-top: var(--space-lg);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.links {
+  display: flex;
+  gap: var(--space-md);
+  flex-wrap: wrap;
+}
+
+.link {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-bold);
+  padding: var(--space-sm) var(--space-lg);
+  border: var(--border-medium);
+  box-shadow: var(--shadow-brutal-sm);
+  text-transform: uppercase;
+}
+
+.link:hover {
+  background-color: var(--color-text);
+  color: var(--color-bg);
+  transform: translate(-2px, -2px);
+  box-shadow: 6px 6px 0 var(--color-text);
+}
+
+@media (max-width: 768px) {
+  .page {
+    padding: var(--space-2xl) var(--space-md);
+  }
+
+  .terminalBody {
+    padding: var(--space-lg) var(--space-md);
+  }
+
+  .errorCode {
+    font-size: var(--text-3xl);
+  }
+
+  .links {
+    flex-direction: column;
+  }
+
+  .link {
+    text-align: center;
+    box-shadow: 3px 3px 0 var(--color-text);
+  }
+
+  .link:hover {
+    transform: none;
+    box-shadow: 3px 3px 0 var(--color-text);
+  }
+}

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,54 @@
+import Link from "next/link";
+import styles from "./not-found.module.css";
+
+export default function NotFound() {
+  return (
+    <div className={styles.page}>
+      <div className={styles.terminal}>
+        <div className={styles.terminalBar}>
+          <div className={styles.terminalDots} aria-hidden="true">
+            <span className={styles.terminalDot} />
+            <span className={styles.terminalDot} />
+            <span className={styles.terminalDot} />
+          </div>
+          <span className={styles.terminalTitle}>bash — error</span>
+        </div>
+        <div className={styles.terminalBody}>
+          <p className={styles.line}>
+            <span className={styles.prompt}>$</span> cd /requested-page
+          </p>
+          <p className={styles.error}>
+            bash: cd: /requested-page: No such file or directory
+          </p>
+          <p className={styles.line}>
+            <span className={styles.prompt}>$</span> echo $?
+          </p>
+          <p className={styles.errorCode}>404</p>
+          <p className={styles.line}>
+            <span className={styles.prompt}>$</span> cat error.log
+          </p>
+          <p className={styles.message}>
+            The page you&apos;re looking for doesn&apos;t exist or has been
+            moved.
+          </p>
+          <div className={styles.actions}>
+            <p className={styles.line}>
+              <span className={styles.prompt}>$</span> _
+            </p>
+            <div className={styles.links}>
+              <Link href="/" className={styles.link}>
+                cd ~
+              </Link>
+              <Link href="/blog" className={styles.link}>
+                cd ~/blog
+              </Link>
+              <Link href="/presentations" className={styles.link}>
+                cd ~/talks
+              </Link>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -60,7 +60,7 @@ export default function Home() {
       </div>
 
       {/* About — window panel */}
-      <section aria-labelledby="about-heading">
+      <section aria-labelledby="about-heading" className="fade-in fade-in-1">
         <div className={styles.window}>
           <div className={styles.windowBar}>
             <span className={styles.windowLabel} id="about-heading">
@@ -77,7 +77,7 @@ export default function Home() {
       </section>
 
       {/* Focus — window panel */}
-      <section aria-labelledby="focus-heading">
+      <section aria-labelledby="focus-heading" className="fade-in fade-in-2">
         <div className={styles.window}>
           <div className={styles.windowBar}>
             <span className={styles.windowLabel} id="focus-heading">
@@ -106,7 +106,7 @@ export default function Home() {
       </section>
 
       {/* Speaking — window panel */}
-      <section aria-labelledby="speaking-heading">
+      <section aria-labelledby="speaking-heading" className="fade-in fade-in-3">
         <div className={styles.window}>
           <div className={styles.windowBar}>
             <span className={styles.windowLabel} id="speaking-heading">
@@ -155,7 +155,7 @@ export default function Home() {
       </section>
 
       {/* Connect — window panel */}
-      <section aria-labelledby="connect-heading">
+      <section aria-labelledby="connect-heading" className="fade-in fade-in-4">
         <div className={styles.window}>
           <div className={styles.windowBar}>
             <span className={styles.windowLabel} id="connect-heading">

--- a/components/PresentationViewer.module.css
+++ b/components/PresentationViewer.module.css
@@ -4,10 +4,87 @@
   flex-direction: column;
   min-height: calc(100vh - 80px);
   background-color: var(--color-bg);
+  border: var(--border-medium);
+  margin: var(--space-lg);
+  overflow: hidden;
 }
 
 .fullscreen {
   min-height: 100vh;
+  margin: 0;
+  border: none;
+}
+
+/* === Top toolbar === */
+.controls {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-sm) var(--space-md);
+  background-color: var(--color-text);
+  color: var(--color-bg);
+  border-bottom: var(--border-medium);
+}
+
+.navGroup {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+}
+
+.navButton {
+  font-family: var(--font-mono);
+  font-size: var(--text-base);
+  font-weight: var(--weight-bold);
+  background: none;
+  border: 1px solid var(--color-bg);
+  color: var(--color-bg);
+  padding: var(--space-xs) var(--space-sm);
+  cursor: pointer;
+}
+
+.navButton:hover:not(:disabled) {
+  background-color: var(--color-bg);
+  color: var(--color-text);
+}
+
+.navButton:disabled {
+  opacity: 0.2;
+  cursor: default;
+}
+
+.counter {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-bold);
+  color: var(--color-bg);
+  min-width: 60px;
+  text-align: center;
+  letter-spacing: 0.1em;
+}
+
+.controlGroup {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+}
+
+.controlButton {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-bold);
+  background: none;
+  border: 1px solid var(--color-bg);
+  color: var(--color-bg);
+  padding: var(--space-xs) var(--space-sm);
+  cursor: pointer;
+  opacity: 0.6;
+}
+
+.controlButton:hover {
+  background-color: var(--color-bg);
+  color: var(--color-text);
+  opacity: 1;
 }
 
 /* === Slide Container === */
@@ -46,87 +123,29 @@
   line-height: var(--leading-relaxed);
 }
 
-/* === Controls === */
-.controls {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: var(--space-md);
-  padding: var(--space-sm) var(--space-lg);
-  border-top: var(--border-thin);
-}
-
-.navButton {
-  font-family: var(--font-mono);
-  font-size: var(--text-lg);
-  font-weight: var(--weight-bold);
-  background: none;
-  border: none;
-  color: var(--color-text);
-  padding: var(--space-xs) var(--space-sm);
-  cursor: pointer;
-}
-
-.navButton:hover:not(:disabled) {
-  background-color: var(--color-text);
-  color: var(--color-bg);
-}
-
-.navButton:disabled {
-  color: var(--color-border-muted);
-  cursor: default;
-}
-
-.counter {
-  font-family: var(--font-mono);
-  font-size: var(--text-sm);
-  font-weight: var(--weight-bold);
-  color: var(--color-text-muted);
-  min-width: 60px;
-  text-align: center;
-}
-
-.controlButton {
-  font-family: var(--font-mono);
-  font-size: var(--text-sm);
-  font-weight: var(--weight-bold);
-  background: none;
-  border: none;
-  color: var(--color-text-muted);
-  padding: var(--space-xs) var(--space-sm);
-  cursor: pointer;
-}
-
-.controlButton:hover {
-  background-color: var(--color-text);
-  color: var(--color-bg);
-}
-
 /* === Progress Bar === */
 .progressBar {
-  height: 2px;
+  height: 3px;
   background-color: var(--color-border-muted);
 }
 
 .progressFill {
   height: 100%;
   background-color: var(--color-text);
-  transition: width 0.2s ease;
 }
 
 /* === Fullscreen === */
 .fullscreen .controls {
   position: fixed;
-  bottom: 0;
+  top: 0;
   left: 0;
   right: 0;
-  background-color: var(--color-bg);
   z-index: 10;
 }
 
 .fullscreen .progressBar {
   position: fixed;
-  bottom: 44px;
+  bottom: 0;
   left: 0;
   right: 0;
   z-index: 10;
@@ -134,17 +153,24 @@
 
 .fullscreen .notesPanel {
   position: fixed;
-  bottom: 46px;
+  bottom: 3px;
   left: 0;
   right: 0;
   z-index: 10;
 }
 
+.fullscreen .slideContainer {
+  padding-top: 48px;
+}
+
 /* === Mobile === */
 @media (max-width: 768px) {
+  .viewer {
+    margin: var(--space-sm);
+  }
+
   .controls {
-    gap: var(--space-sm);
-    padding: var(--space-xs) var(--space-md);
+    padding: var(--space-xs) var(--space-sm);
   }
 
   .counter {

--- a/components/PresentationViewer.tsx
+++ b/components/PresentationViewer.tsx
@@ -153,6 +153,52 @@ export function PresentationViewer({ slides, slug }: PresentationViewerProps) {
       onTouchStart={handleTouchStart}
       onTouchEnd={handleTouchEnd}
     >
+      {/* Controls — top toolbar */}
+      <div className={styles.controls}>
+        <div className={styles.navGroup}>
+          <button
+            className={styles.navButton}
+            onClick={prev}
+            disabled={currentSlide === 1}
+            aria-label="Previous slide"
+          >
+            &larr;
+          </button>
+
+          <span className={styles.counter} aria-live="polite">
+            {currentSlide} / {totalSlides}
+          </span>
+
+          <button
+            className={styles.navButton}
+            onClick={next}
+            disabled={currentSlide === totalSlides}
+            aria-label="Next slide"
+          >
+            &rarr;
+          </button>
+        </div>
+
+        <div className={styles.controlGroup}>
+          <button
+            className={styles.controlButton}
+            onClick={() => setShowNotes(!showNotes)}
+            aria-label={showNotes ? "Hide speaker notes" : "Show speaker notes"}
+            aria-pressed={showNotes}
+          >
+            [N]
+          </button>
+
+          <button
+            className={styles.controlButton}
+            onClick={toggleFullscreen}
+            aria-label={isFullscreen ? "Exit fullscreen" : "Enter fullscreen"}
+          >
+            {isFullscreen ? "[×]" : "[□]"}
+          </button>
+        </div>
+      </div>
+
       <div className={styles.slideContainer}>
         <SlideRenderer slide={slide} />
       </div>
@@ -164,48 +210,6 @@ export function PresentationViewer({ slides, slug }: PresentationViewerProps) {
           <p className={styles.notesText}>{notes}</p>
         </div>
       )}
-
-      {/* Controls */}
-      <div className={styles.controls}>
-        <button
-          className={styles.navButton}
-          onClick={prev}
-          disabled={currentSlide === 1}
-          aria-label="Previous slide"
-        >
-          &larr;
-        </button>
-
-        <span className={styles.counter} aria-live="polite">
-          {currentSlide} / {totalSlides}
-        </span>
-
-        <button
-          className={styles.navButton}
-          onClick={next}
-          disabled={currentSlide === totalSlides}
-          aria-label="Next slide"
-        >
-          &rarr;
-        </button>
-
-        <button
-          className={styles.controlButton}
-          onClick={() => setShowNotes(!showNotes)}
-          aria-label={showNotes ? "Hide speaker notes" : "Show speaker notes"}
-          aria-pressed={showNotes}
-        >
-          [N]
-        </button>
-
-        <button
-          className={styles.controlButton}
-          onClick={toggleFullscreen}
-          aria-label={isFullscreen ? "Exit fullscreen" : "Enter fullscreen"}
-        >
-          {isFullscreen ? "[X]" : "[F]"}
-        </button>
-      </div>
 
       {/* Progress Bar */}
       <div

--- a/components/SlideRenderer.module.css
+++ b/components/SlideRenderer.module.css
@@ -111,17 +111,54 @@
   font-weight: var(--weight-bold);
 }
 
-/* === Code Slide === */
-.codeBlock {
+/* === Code Slide (terminal window) === */
+.codeWindow {
   width: 100%;
   max-width: 700px;
-  background-color: var(--color-bg-secondary);
   border: var(--border-medium);
+  box-shadow: var(--shadow-brutal-sm);
+  overflow: hidden;
+}
+
+.codeBar {
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+  padding: var(--space-xs) var(--space-md);
+  background-color: var(--color-text);
+  color: var(--color-bg);
+  border-bottom: var(--border-medium);
+}
+
+.codeDots {
+  display: flex;
+  gap: 6px;
+}
+
+.codeDot {
+  width: 10px;
+  height: 10px;
+  border: 2px solid var(--color-bg);
+  display: inline-block;
+}
+
+.codeLabel {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-bold);
+  letter-spacing: 0.05em;
+}
+
+.codeBlock {
+  width: 100%;
+  background-color: var(--color-bg-secondary);
   padding: var(--space-lg);
   overflow-x: auto;
   font-family: var(--font-mono);
   font-size: var(--text-sm);
   line-height: var(--leading-normal);
+  border: none;
+  margin: 0;
 }
 
 .codeBlock code {

--- a/components/SlideRenderer.tsx
+++ b/components/SlideRenderer.tsx
@@ -70,9 +70,21 @@ export function SlideRenderer({ slide }: SlideRendererProps) {
       return (
         <div className={`${styles.slide} ${styles.codeSlide}`}>
           <h2 className={styles.heading}>{slide.title}</h2>
-          <pre className={styles.codeBlock}>
-            <code>{slide.code}</code>
-          </pre>
+          <div className={styles.codeWindow}>
+            <div className={styles.codeBar}>
+              <div className={styles.codeDots} aria-hidden="true">
+                <span className={styles.codeDot} />
+                <span className={styles.codeDot} />
+                <span className={styles.codeDot} />
+              </div>
+              <span className={styles.codeLabel}>
+                {slide.caption || "code.sh"}
+              </span>
+            </div>
+            <pre className={styles.codeBlock}>
+              <code>{slide.code}</code>
+            </pre>
+          </div>
           {slide.caption && (
             <p className={styles.caption}>{slide.caption}</p>
           )}

--- a/styles/variables.css
+++ b/styles/variables.css
@@ -88,4 +88,7 @@
 
   --shadow-brutal: var(--shadow-offset) var(--shadow-offset) 0 var(--color-text);
   --shadow-brutal-sm: 4px 4px 0 var(--color-text);
+
+  /* === Transition === */
+  --transition-lift: transform 0.15s ease-out, box-shadow 0.15s ease-out;
 }


### PR DESCRIPTION
## Summary
- Custom **404 page** styled as a terminal "command not found" error with navigation links (`cd ~`, `cd ~/blog`, `cd ~/talks`)
- **Presentation viewer** controls restructured — toolbar moved to top with grouped navigation and control buttons, fullscreen/notes icons updated to `[□]`/`[×]`/`[N]`
- **Code slides** in presentations now render as terminal windows with inverted title bar, dots, and filename label
- **Staggered fade-in animations** on home page window panels (subtle 12px translateY + opacity)
- Added `--transition-lift` design token to variables

Closes #49

## Test plan
- [x] All 56 tests pass
- [x] Static build succeeds
- [ ] Verify 404 page renders at `/nonexistent-path`
- [ ] Verify presentation viewer controls are at top with correct grouping
- [ ] Verify code slides show terminal window chrome
- [ ] Verify home page sections animate in on load
- [ ] Test light mode appearance

🤖 Generated with [Claude Code](https://claude.com/claude-code)