### PR TITLE
chore: switch canonical domain to rajnavakoti.com

### DIFF
--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -112,7 +112,7 @@ Built with neo-brutalist monochrome design. Deployable to Vercel (primary) and G
 - Connect GitHub repo to Vercel
 - Auto-deploy on push to main
 - Preview deployments on PRs
-- Custom domain: rajnavakoti.dev (or similar, TBD)
+- Custom domain: rajnavakoti.com
 
 ### Phase 3: GCP (future, optional)
 - Cloud Run or Firebase Hosting

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -12,7 +12,7 @@ const jetbrainsMono = JetBrains_Mono({
   display: "swap",
 });
 
-const siteUrl = "https://rajnavakoti.dev";
+const siteUrl = "https://rajnavakoti.com";
 
 export const metadata: Metadata = {
   title: {

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -8,6 +8,6 @@ export default function robots(): MetadataRoute.Robots {
       userAgent: "*",
       allow: "/",
     },
-    sitemap: "https://rajnavakoti.dev/sitemap.xml",
+    sitemap: "https://rajnavakoti.com/sitemap.xml",
   };
 }

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -5,7 +5,7 @@ export const dynamic = "force-static";
 import { getAllSlugs } from "@/lib/writings";
 import { getAllPresentationSlugs } from "@/lib/presentations";
 
-const siteUrl = "https://rajnavakoti.dev";
+const siteUrl = "https://rajnavakoti.com";
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const writingSlugs = getAllSlugs();

--- a/app/writings/[slug]/page.tsx
+++ b/app/writings/[slug]/page.tsx
@@ -21,7 +21,7 @@ export async function generateMetadata({
   const writing = getWritingBySlug(slug);
   if (!writing) return {};
 
-  const url = `https://rajnavakoti.dev/writings/${slug}`;
+  const url = `https://rajnavakoti.com/writings/${slug}`;
 
   return {
     title: writing.frontmatter.title,

--- a/content/presentations/ai-engineer-workshop.mdx
+++ b/content/presentations/ai-engineer-workshop.mdx
@@ -13,7 +13,7 @@ Title slide. Let it sit for a moment while people settle in. Don't start talking
 
 ---
 
-<SpeakerCard name="Raj Navakoti" photo="/profile pic.png" role="Staff Software Engineer" org="@Ingka Digital, IKEA" interests="AI Architecture, Neuroscience, Linguistics" link1="WEB — rajnavakoti.dev" link2="LI — linkedin.com/in/rajnavakoti" link3="GH — github.com/rajnavakoti" qrUrl="https://rajnavakoti.dev" />
+<SpeakerCard name="Raj Navakoti" photo="/profile pic.png" role="Staff Software Engineer" org="@Ingka Digital, IKEA" interests="AI Architecture, Neuroscience, Linguistics" link1="WEB — rajnavakoti.com" link2="LI — linkedin.com/in/rajnavakoti" link3="GH — github.com/rajnavakoti" qrUrl="https://rajnavakoti.com" />
 
 <Notes>
 Welcome everyone. I'm Raj — I work at IKEA Digital on supply chain logistics. For the past few months I've been obsessed with one question: why do our AI agents fail on domain-specific work? This workshop is the answer I found. Let's go.


### PR DESCRIPTION
## Summary
- Replace `rajnavakoti.dev` placeholder with the live custom domain `rajnavakoti.com` across all metadata + canonical URLs.
- Updates: `app/layout.tsx`, `app/sitemap.ts`, `app/robots.ts`, `app/writings/[slug]/page.tsx`, plus the AI.engineer workshop deck (SpeakerCard link + QR code target) and `REQUIREMENTS.md`.

## Test plan
- [x] `npm test` — 76/76 pass
- [x] `npm run build` — succeeds, 16 static pages generated
- [x] `grep` confirms zero remaining `rajnavakoti.dev` or `rajnavakoti-dev.web.app` references in source
- [ ] Post-merge: verify `https://rajnavakoti.com/sitemap.xml` lists all pages
- [ ] Post-merge: verify `<meta property="og:url">` on a writing page renders with `rajnavakoti.com`

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)