### PR TITLE
chore: remove employer references from public site

### DIFF
--- a/components/mdx-slides/SpeakerCard.tsx
+++ b/components/mdx-slides/SpeakerCard.tsx
@@ -4,7 +4,7 @@ interface SpeakerCardProps {
   name: string;
   photo: string;
   role: string;
-  org: string;
+  org?: string;
   interests?: string;
   link1?: string;
   link2?: string;
@@ -41,7 +41,7 @@ export function SpeakerCard({
           </div>
           <div className={styles.speakerInfo}>
             <div className={styles.speakerRole}>{role}</div>
-            <div className={styles.speakerOrg}>{org}</div>
+            {org && <div className={styles.speakerOrg}>{org}</div>}
             {interestList.length > 0 && (
               <div className={styles.speakerInterests}>
                 {interestList.map((item, i) => (

--- a/content/presentations/ai-builders-ddc.json
+++ b/content/presentations/ai-builders-ddc.json
@@ -40,12 +40,12 @@
     },
     {
       "type": "content",
-      "title": "IKEA vs Your Enterprise",
+      "title": "A Warehouse Store vs Your Enterprise",
       "body": [
         "Physical world: Clear pathways, numbered sections, you walk in with a list and walk out with exactly what you need.",
         "Digital world: Hundreds of systems, thousands of APIs, tribal knowledge locked in people's heads, docs scattered everywhere."
       ],
-      "notes": "Anyone who's shopped at IKEA knows how easy it is to navigate. But look at the digital side of any enterprise. No clear path. No numbered arrows."
+      "notes": "Anyone who's shopped at a well-organized warehouse store knows how easy it is to navigate. But look at the digital side of any enterprise. No clear path. No numbered arrows."
     },
     {
       "type": "content",

--- a/content/presentations/ai-engineer-workshop.mdx
+++ b/content/presentations/ai-engineer-workshop.mdx
@@ -13,10 +13,10 @@ Title slide. Let it sit for a moment while people settle in. Don't start talking
 
 ---
 
-<SpeakerCard name="Raj Navakoti" photo="/profile pic.png" role="Staff Software Engineer" org="@Ingka Digital, IKEA" interests="AI Architecture, Neuroscience, Linguistics" link1="WEB — rajnavakoti.com" link2="LI — linkedin.com/in/rajnavakoti" link3="GH — github.com/rajnavakoti" qrUrl="https://rajnavakoti.com" />
+<SpeakerCard name="Raj Navakoti" photo="/profile pic.png" role="Staff Software Engineer" interests="AI Architecture, Neuroscience, Linguistics" link1="WEB — rajnavakoti.com" link2="LI — linkedin.com/in/rajnavakoti" link3="GH — github.com/rajnavakoti" qrUrl="https://rajnavakoti.com" />
 
 <Notes>
-Welcome everyone. I'm Raj — I work at IKEA Digital on supply chain logistics. For the past few months I've been obsessed with one question: why do our AI agents fail on domain-specific work? This workshop is the answer I found. Let's go.
+Welcome everyone. I'm Raj. I've spent the past few years on enterprise AI in supply chain and logistics, and the past few months obsessing over one question: why do our AI agents fail on domain-specific work? This workshop is the answer I found. Let's go.
 </Notes>
 
 ---
@@ -448,7 +448,7 @@ If scanner is slow or breaks: show pre-run screenshots. Have 3 domain results pr
 
 ## The Meta Model — Your Store Map
 
-> *"Think of it like the map at the entrance of an **IKEA** store."*
+> *"Think of it like the floor plan at the entrance of a **museum**."*
 
 <Split ratio="1:1">
 <div>
@@ -466,7 +466,7 @@ If scanner is slow or breaks: show pre-run screenshots. Have 3 domain results pr
 </Split>
 
 <Notes>
-"You know the map at the entrance of IKEA? Shows where everything is and how departments connect. The meta model is the same thing for your domain. 13 entity types. Relationships between them. An agent working on an incident can trace from a system to its dependencies to the team that owns it. Not mandatory to start — you can begin with just systems and jargon — but powerful as the knowledge base grows."
+"You know the floor plan at the entrance of a museum? Shows where everything is and how the wings connect. The meta model is the same thing for your domain. 13 entity types. Relationships between them. An agent working on an incident can trace from a system to its dependencies to the team that owns it. Not mandatory to start — you can begin with just systems and jargon — but powerful as the knowledge base grows."
 </Notes>
 
 ---
@@ -587,7 +587,7 @@ Open Q&A. Don't be defensive. Engage honestly. "That's a good point — here's w
 
 ## Thank You
 
-**Raj Navakoti** — IKEA Digital, Delivery & Services
+**Raj Navakoti** — Staff Software Engineer
 
 <ContentCard title="RESOURCES" accent="amber" items="Paper: Demand-Driven Context — ask me for the arxiv link, Scanner: URL on screen, Template: github.com/ea-toolkit/ddc → GETTING-STARTED.md, Find me during the networking — happy to chat" />
 


### PR DESCRIPTION
## Summary
- Removes all IKEA / Ingka mentions from tracked content (slides, speaker cards, speaker notes).
- Makes \`SpeakerCard.org\` optional and renders nothing when omitted.
- Substitutes analogies while preserving the meaning: workshop deck uses a museum floor plan; AI builders deck uses a warehouse store.

## Why
The site is personal + professional but should not be tied to a current employer.

## Test plan
- [x] \`grep -ri 'ikea\\|ingka' content/ components/ app/\` returns zero hits in tracked files
- [x] \`npm test\` — 76/76 pass
- [x] \`npm run build\` — succeeds, all 16 static pages generated

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)