### PR TITLE
feat: add YouTubeEmbed and feature AI.engineer workshop video

### DIFF
--- a/app/page.module.css
+++ b/app/page.module.css
@@ -299,6 +299,23 @@
   min-height: 80px;
 }
 
+/* === VIDEO.mp4 === */
+.videoDeckLink {
+  display: inline-block;
+  margin-top: var(--space-md);
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  color: var(--color-accent);
+  text-decoration: underline;
+  text-underline-offset: 4px;
+  letter-spacing: 0.05em;
+  transition: color var(--transition-fast);
+}
+
+.videoDeckLink:hover {
+  color: var(--color-accent-hover);
+}
+
 /* ============================================
    ABOUT
    ============================================ */

--- a/app/page.test.tsx
+++ b/app/page.test.tsx
@@ -27,6 +27,15 @@ describe("Home", () => {
     ).toBeInTheDocument();
   });
 
+  it("renders featured video section with play button", () => {
+    render(<Home />);
+    expect(screen.getByText("VIDEO.mp4")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /play video/i })
+    ).toBeInTheDocument();
+    expect(screen.getByText(/View slides/)).toBeInTheDocument();
+  });
+
   it("renders speaking window with talks", () => {
     render(<Home />);
     expect(screen.getByText("TALKS.json")).toBeInTheDocument();

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,6 +6,7 @@ import { TerminalSnippet } from "@/components/TerminalSnippet";
 import { GeoPattern } from "@/components/GeoPattern";
 import { DotMatrix } from "@/components/DotMatrix";
 import { SkillsChart } from "@/components/SkillsChart";
+import { YouTubeEmbed } from "@/components/YouTubeEmbed";
 import styles from "./page.module.css";
 
 export default function Home() {
@@ -158,8 +159,32 @@ export default function Home() {
         </div>
       </section>
 
+      {/* Featured Video */}
+      {profile.featuredVideo && (
+        <section aria-labelledby="video-heading" className="fade-in fade-in-4">
+          <div className={styles.sectionHeader}>
+            <span className={styles.sectionLabel} id="video-heading">
+              VIDEO.mp4
+            </span>
+            <span className={styles.sectionControls} aria-hidden="true">
+              [&minus;] [&square;] [&times;]
+            </span>
+          </div>
+          <div className={styles.sectionBody}>
+            <YouTubeEmbed
+              videoId={profile.featuredVideo.videoId}
+              title={profile.featuredVideo.title}
+              caption={`${profile.featuredVideo.event} — ${profile.featuredVideo.date}`}
+            />
+            <a href={profile.featuredVideo.href} className={styles.videoDeckLink}>
+              View slides &rarr;
+            </a>
+          </div>
+        </section>
+      )}
+
       {/* Speaking — with geo pattern background */}
-      <section aria-labelledby="speaking-heading" className="fade-in fade-in-4">
+      <section aria-labelledby="speaking-heading" className="fade-in fade-in-5">
         <div className={styles.sectionHeader}>
           <span className={styles.sectionLabel} id="speaking-heading">
             TALKS.json
@@ -256,7 +281,7 @@ export default function Home() {
       </section>
 
       {/* Connect — with network illustration */}
-      <section aria-labelledby="connect-heading" className="fade-in fade-in-5">
+      <section aria-labelledby="connect-heading" className="fade-in fade-in-6">
         <div className={styles.sectionHeader}>
           <span className={styles.sectionLabel} id="connect-heading">
             LINKS.sh

--- a/app/presentations/[slug]/page.module.css
+++ b/app/presentations/[slug]/page.module.css
@@ -4,6 +4,38 @@
   gap: var(--space-xl);
 }
 
+/* === Recording (YouTube embed) === */
+.recording {
+  max-width: var(--max-width-narrow);
+  margin: 0 auto;
+  padding: var(--space-xl) var(--space-lg) 0;
+  width: 100%;
+}
+
+.recordingHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: var(--space-md);
+  padding-bottom: var(--space-sm);
+  border-bottom: 2px solid var(--color-accent);
+}
+
+.recordingLabel {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  font-weight: var(--weight-bold);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--color-accent);
+}
+
+.recordingMeta {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+}
+
 /* === Photo Gallery — 2x2 grid === */
 .gallery {
   max-width: var(--max-width-narrow);

--- a/app/presentations/[slug]/page.tsx
+++ b/app/presentations/[slug]/page.tsx
@@ -9,6 +9,7 @@ import {
 import { compileMdxSlides } from "@/lib/compile-mdx-slides";
 import { SlideRenderer } from "@/components/SlideRenderer";
 import { PresentationViewer } from "@/components/PresentationViewer";
+import { YouTubeEmbed } from "@/components/YouTubeEmbed";
 import type { Metadata } from "next";
 import styles from "./page.module.css";
 
@@ -58,9 +59,25 @@ export default async function PresentationPage({ params }: PageProps) {
     ));
     const notes = compiled.map((slide) => slide.notes);
     const hasPhotos = mdxPres.photos && mdxPres.photos.length > 0;
+    const hasVideo = !!mdxPres.videoId;
 
     return (
       <div className={styles.page}>
+        {hasVideo && (
+          <div className={styles.recording}>
+            <div className={styles.recordingHeader}>
+              <span className={styles.recordingLabel}>RECORDING</span>
+              <span className={styles.recordingMeta}>
+                {mdxPres.frontmatter.event} &mdash; {mdxPres.frontmatter.date}
+              </span>
+            </div>
+            <YouTubeEmbed
+              videoId={mdxPres.videoId!}
+              title={mdxPres.videoTitle ?? mdxPres.frontmatter.title}
+            />
+          </div>
+        )}
+
         {hasPhotos && (
           <div className={styles.gallery}>
             <div className={styles.galleryHeader}>

--- a/components/YouTubeEmbed.module.css
+++ b/components/YouTubeEmbed.module.css
@@ -1,0 +1,147 @@
+.figure {
+  margin: 0;
+  width: 100%;
+}
+
+.frame {
+  position: relative;
+  display: block;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  background-color: var(--color-bg-secondary);
+  border: var(--border-medium);
+  overflow: hidden;
+}
+
+.iframe {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+}
+
+.button {
+  display: block;
+  width: 100%;
+  padding: 0;
+  background: none;
+  border: 0;
+  cursor: pointer;
+  font: inherit;
+  color: inherit;
+}
+
+.button:focus-visible {
+  outline: none;
+}
+
+.button:focus-visible .frame {
+  border-color: var(--color-accent);
+  outline: var(--border-thick);
+  outline-offset: 4px;
+}
+
+.thumbnail {
+  object-fit: cover;
+  filter: grayscale(0.15) contrast(1.05);
+  transition: filter var(--transition-base);
+}
+
+.button:hover .thumbnail,
+.button:focus-visible .thumbnail {
+  filter: grayscale(0) contrast(1);
+}
+
+.overlay {
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(
+    180deg,
+    transparent 0%,
+    transparent 55%,
+    rgba(0, 0, 0, 0.65) 100%
+  );
+  pointer-events: none;
+}
+
+.playBadge {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 88px;
+  height: 62px;
+  color: var(--color-text);
+  background-color: var(--color-bg);
+  border: var(--border-medium);
+  transition:
+    background-color var(--transition-fast),
+    color var(--transition-fast),
+    transform var(--transition-fast);
+  pointer-events: none;
+}
+
+.button:hover .playBadge,
+.button:focus-visible .playBadge {
+  background-color: var(--color-accent);
+  color: var(--color-accent-text);
+  transform: translate(-50%, -50%) scale(1.05);
+}
+
+.titleBar {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-md);
+  padding: var(--space-md) var(--space-lg);
+  background-color: rgba(0, 0, 0, 0.7);
+  border-top: var(--border-medium);
+  color: #fff;
+  text-align: left;
+}
+
+.titleLabel {
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  letter-spacing: 0.18em;
+  color: var(--color-accent);
+  white-space: nowrap;
+}
+
+.titleText {
+  font-family: var(--font-mono);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  line-height: var(--leading-tight);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.caption {
+  margin-top: var(--space-sm);
+  font-family: var(--font-mono);
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+  letter-spacing: 0.05em;
+}
+
+@media (max-width: 480px) {
+  .playBadge {
+    width: 64px;
+    height: 46px;
+  }
+
+  .titleBar {
+    padding: var(--space-sm) var(--space-md);
+  }
+}

--- a/components/YouTubeEmbed.test.tsx
+++ b/components/YouTubeEmbed.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { YouTubeEmbed } from "./YouTubeEmbed";
+
+describe("YouTubeEmbed", () => {
+  const props = {
+    videoId: "_QAVExf_1uw",
+    title: "Demand-Driven Context Workshop",
+  };
+
+  it("renders a play button with the video title initially", () => {
+    render(<YouTubeEmbed {...props} />);
+    const button = screen.getByRole("button", {
+      name: /play video: demand-driven context workshop/i,
+    });
+    expect(button).toBeInTheDocument();
+    expect(screen.queryByTitle(props.title)).not.toBeInTheDocument();
+  });
+
+  it("uses the YouTube hqdefault thumbnail for the video id", () => {
+    const { container } = render(<YouTubeEmbed {...props} />);
+    const img = container.querySelector("img");
+    expect(img).not.toBeNull();
+    expect(img!.getAttribute("src")).toContain(`/${props.videoId}/`);
+  });
+
+  it("loads the embed iframe only after the play button is clicked", () => {
+    render(<YouTubeEmbed {...props} />);
+    expect(document.querySelector("iframe")).toBeNull();
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /play video: demand-driven context workshop/i,
+      })
+    );
+
+    const iframe = document.querySelector("iframe");
+    expect(iframe).not.toBeNull();
+    expect(iframe!.getAttribute("src")).toContain(`/embed/${props.videoId}`);
+    expect(iframe!.getAttribute("title")).toBe(props.title);
+    expect(iframe!.getAttribute("allowFullScreen")).not.toBeNull();
+  });
+
+  it("renders a caption when provided", () => {
+    render(<YouTubeEmbed {...props} caption="AI.engineer Europe 2026" />);
+    expect(screen.getByText("AI.engineer Europe 2026")).toBeInTheDocument();
+  });
+});

--- a/components/YouTubeEmbed.tsx
+++ b/components/YouTubeEmbed.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useState } from "react";
+import Image from "next/image";
+import styles from "./YouTubeEmbed.module.css";
+
+export interface YouTubeEmbedProps {
+  videoId: string;
+  title: string;
+  caption?: string;
+}
+
+export function YouTubeEmbed({ videoId, title, caption }: YouTubeEmbedProps) {
+  const [loaded, setLoaded] = useState(false);
+  const thumbnail = `https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`;
+  const embedUrl = `https://www.youtube-nocookie.com/embed/${videoId}?autoplay=1&rel=0`;
+
+  if (loaded) {
+    return (
+      <figure className={styles.figure}>
+        <div className={styles.frame}>
+          <iframe
+            src={embedUrl}
+            title={title}
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+            allowFullScreen
+            className={styles.iframe}
+          />
+        </div>
+        {caption && <figcaption className={styles.caption}>{caption}</figcaption>}
+      </figure>
+    );
+  }
+
+  return (
+    <figure className={styles.figure}>
+      <button
+        type="button"
+        className={styles.button}
+        onClick={() => setLoaded(true)}
+        aria-label={`Play video: ${title}`}
+      >
+        <span className={styles.frame}>
+          <Image
+            src={thumbnail}
+            alt=""
+            fill
+            className={styles.thumbnail}
+            unoptimized
+            priority={false}
+          />
+          <span className={styles.overlay} aria-hidden="true" />
+          <span className={styles.playBadge} aria-hidden="true">
+            <svg viewBox="0 0 68 48" width="68" height="48" focusable="false">
+              <path
+                d="M66.52 7.74c-.78-2.93-2.49-5.41-5.42-6.19C55.79.13 34 0 34 0S12.21.13 6.9 1.55c-2.93.78-4.63 3.26-5.42 6.19C.06 13.05 0 24 0 24s.06 10.95 1.48 16.26c.78 2.93 2.49 5.41 5.42 6.19C12.21 47.87 34 48 34 48s21.79-.13 27.1-1.55c2.93-.78 4.64-3.26 5.42-6.19C67.94 34.95 68 24 68 24s-.06-10.95-1.48-16.26z"
+                fill="currentColor"
+              />
+              <path d="M45 24L27 14v20" fill="var(--color-bg)" />
+            </svg>
+          </span>
+          <span className={styles.titleBar}>
+            <span className={styles.titleLabel}>WATCH</span>
+            <span className={styles.titleText}>{title}</span>
+          </span>
+        </span>
+      </button>
+      {caption && <figcaption className={styles.caption}>{caption}</figcaption>}
+    </figure>
+  );
+}

--- a/content/presentations/ai-engineer-workshop.mdx
+++ b/content/presentations/ai-engineer-workshop.mdx
@@ -3,6 +3,8 @@ title: "Build Your First Demand-Driven Context Base"
 event: "AI.engineer Europe 2026"
 date: "2026-04-08"
 description: "Let AI Agents Tell You What They Need — a hands-on workshop on demand-driven context curation for enterprise AI agents."
+videoId: "_QAVExf_1uw"
+videoTitle: "Build Your First Demand-Driven Context Base — AI.engineer Europe Workshop"
 ---
 
 <TitleCard badge="AI.ENGINEER EUROPE 2026 — WORKSHOP" subtitle="Let AI Agents Tell You What They Need">Build Your First Demand-Driven Context Base</TitleCard>

--- a/content/profile.ts
+++ b/content/profile.ts
@@ -4,6 +4,14 @@ export interface SkillGroup {
   items: { name: string; level: number }[];
 }
 
+export interface FeaturedVideo {
+  videoId: string;
+  title: string;
+  event: string;
+  date: string;
+  href: string;
+}
+
 export interface Profile {
   name: string;
   title: string;
@@ -14,6 +22,7 @@ export interface Profile {
   skills: SkillGroup[];
   links: ProfileLink[];
   speaking: SpeakingEngagement[];
+  featuredVideo?: FeaturedVideo;
 }
 
 export interface ProfileLink {
@@ -141,8 +150,8 @@ export const profile: Profile = {
       event: "AI.engineer",
       date: "2026-04-08",
       location: "London, UK",
-      upcoming: true,
-      url: "https://www.ai.engineer/europe#speakers",
+      upcoming: false,
+      url: "/presentations/ai-engineer-workshop",
       logo: "/talks/ai-engineer-logo.jpg",
     },
     {
@@ -155,4 +164,11 @@ export const profile: Profile = {
       logo: "/talks/ai-builders-logo.jpeg",
     },
   ],
+  featuredVideo: {
+    videoId: "_QAVExf_1uw",
+    title: "Build Your First Demand-Driven Context Base",
+    event: "AI.engineer Europe",
+    date: "2026-04-08",
+    href: "/presentations/ai-engineer-workshop",
+  },
 };

--- a/lib/presentations.ts
+++ b/lib/presentations.ts
@@ -92,6 +92,8 @@ export interface MdxPresentationFrontmatter {
   date: string;
   description: string;
   photos?: string[];
+  videoId?: string;
+  videoTitle?: string;
 }
 
 export interface MdxPresentationRaw {
@@ -99,6 +101,8 @@ export interface MdxPresentationRaw {
   frontmatter: MdxPresentationFrontmatter;
   slideContents: string[];
   photos?: string[];
+  videoId?: string;
+  videoTitle?: string;
 }
 
 export interface Presentation {
@@ -224,6 +228,8 @@ export function getMdxPresentationBySlug(
     frontmatter: fm,
     slideContents: splitMdxSlides(content),
     photos: fm.photos,
+    videoId: fm.videoId,
+    videoTitle: fm.videoTitle,
   };
 }
 


### PR DESCRIPTION
## Summary
- New \`<YouTubeEmbed>\` component using the lite-embed pattern: static thumbnail + play button initially, iframe loads only on click. Saves ~1MB on first paint and avoids YouTube cookies until interaction (uses \`youtube-nocookie.com\`).
- Featured video placed in two spots: a new \`VIDEO.mp4\` section on the homepage (between \`SKILLS.config\` and \`TALKS.json\`), and at the top of \`/presentations/ai-engineer-workshop\` above the slide viewer.
- \`MdxPresentationFrontmatter\` gets optional \`videoId\` + \`videoTitle\` so any future MDX presentation with a recording renders the embed automatically.
- Profile gets optional \`featuredVideo\` field — the homepage section is purely data-driven.
- AI.engineer talk moved from upcoming to past (event date 2026-04-08, currently 2026-05-10).

## Test plan
- [x] \`npm test\` — 81/81 pass (4 new YouTubeEmbed tests + 1 new homepage test)
- [x] \`npm run build\` — succeeds, all 16 static pages generated
- [x] Component is keyboard-accessible: button has \`aria-label\`, focus state styled, Enter/Space activates
- [x] Lite-embed: no YouTube iframe in initial DOM (verified by test)
- [ ] Post-merge: visually check at 320px, 768px, 1440px

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)