### PR TITLE
fix(deck): clamp BCM parseVersion to 7, drop dead v=8 branch (unblocks Firebase deploy)

### DIFF
--- a/components/mdx-slides/BoundedContextMap.tsx
+++ b/components/mdx-slides/BoundedContextMap.tsx
@@ -528,7 +528,7 @@ const STATUS_CLASS: Record<Status, string> = {
 function parseVersion(raw: string | number): BoundedContextMapVersion {
   const n = Number.parseInt(String(raw), 10);
   if (!Number.isFinite(n) || n < 0) return 0;
-  if (n > 8) return 8;
+  if (n > 7) return 7;
   return n as BoundedContextMapVersion;
 }
 
@@ -775,17 +775,6 @@ export function BoundedContextMap({ version }: Props) {
             );
           })}
 
-          {/* v0.8 only: ghost-of-Shipment + ghost-of-Carrier struck-through */}
-          {v === 8 && (
-            <g className={styles.statusRed}>
-              <text x={290} y={155} className={styles.mergedGhostLabel} textAnchor="middle">
-                <tspan className={styles.mergedStrike}>Shipment</tspan>
-              </text>
-              <text x={590} y={155} className={styles.mergedGhostLabel} textAnchor="middle">
-                <tspan className={styles.mergedStrike}>Carrier</tspan>
-              </text>
-            </g>
-          )}
 
           {/* Exhibit tag in the top-right corner of the canvas — small
               anchor so the audience always knows which exhibit just landed. */}


### PR DESCRIPTION
## Why

The Firebase deploy on `main` (after #95 and #96 merged) is failing during `next build` with:

```
./components/mdx-slides/BoundedContextMap.tsx:531:14
Type error: Type '8' is not assignable to type 'BoundedContextMapVersion'.
```

The site is therefore still serving the pre-#92 version. The talk is in 3 days, so this needs to land fast.

## What

- `parseVersion` clamped to `7` (the actual `BoundedContextMapVersion` max). The old upper bound of `8` predated the type union being tightened.
- Removed the dead `v === 8` render branch. No MDX slide uses `version="8"` — checked all 8 BCM usages in `ddd-europe-talk.mdx` (0..7 only).

## Verify

- [x] `npm test` — 137/137 passing
- [x] `npm run build` — passes locally
- [x] No behavior change on any rendered slide

🤖 Generated with [Claude Code](https://claude.com/claude-code)